### PR TITLE
Refactor Operation Key Field Values to Named Constants

### DIFF
--- a/src/NewTokenStandard.ts
+++ b/src/NewTokenStandard.ts
@@ -31,6 +31,7 @@ import {
   TransferDynamicProofConfig,
   UpdatesDynamicProofConfig,
   DynamicProofConfig,
+  OperationKeys,
 } from './configs.js';
 import { SideloadedProof } from './side-loaded/program.eg.js';
 
@@ -213,10 +214,10 @@ class FungibleToken extends TokenContract {
     );
 
     const isValidOperationKey = operationKey
-      .equals(Field(1))
-      .or(operationKey.equals(Field(2)))
-      .or(operationKey.equals(Field(3)))
-      .or(operationKey.equals(Field(4)));
+      .equals(OperationKeys.Mint)
+      .or(operationKey.equals(OperationKeys.Burn))
+      .or(operationKey.equals(OperationKeys.Transfer))
+      .or(operationKey.equals(OperationKeys.ApproveBase));
 
     isValidOperationKey.assertTrue('Please enter a valid operation key!');
 
@@ -279,7 +280,7 @@ class FungibleToken extends TokenContract {
       recipient,
       mintDynamicProofConfig,
       vKeyMap,
-      Field(1)
+      OperationKeys.Mint
     );
 
     return accountUpdate;
@@ -323,7 +324,7 @@ class FungibleToken extends TokenContract {
       from,
       burnDynamicProofConfig,
       vKeyMap,
-      Field(2)
+      OperationKeys.Burn
     );
 
     return accountUpdate;
@@ -362,7 +363,7 @@ class FungibleToken extends TokenContract {
       from,
       transferDynamicProofConfig,
       vKeyMap,
-      Field(3)
+      OperationKeys.Transfer
     );
   }
 
@@ -457,7 +458,7 @@ class FungibleToken extends TokenContract {
       PublicKey.empty(),
       updatesDynamicProofConfig,
       vKeyMap,
-      Field(4)
+      OperationKeys.ApproveBase
     );
   }
 

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -10,6 +10,27 @@ export {
   BurnDynamicProofConfig,
   TransferDynamicProofConfig,
   UpdatesDynamicProofConfig,
+  OperationKeys
+};
+
+/**
+ * `OperationKeys` provides symbolic names for the different token operations
+ * that can have associated side-loaded verification keys.
+ *
+ * This ensures type safety and improves readability when referencing
+ * specific operations, for example, in the `VKeyMerkleMap` or when calling
+ * methods like `updateSideLoadedVKeyHash`.
+ *
+ * @property Mint - Operation key for minting tokens (corresponds to Field(1)).
+ * @property Burn - Operation key for burning tokens (corresponds to Field(2)).
+ * @property Transfer - Operation key for transferring tokens (corresponds to Field(3)).
+ * @property ApproveBase - Operation key for approving a forest of account updates (corresponds to Field(4)).
+ */
+const OperationKeys = {
+  Mint: Field(1),
+  Burn: Field(2),
+  Transfer: Field(3),
+  ApproveBase: Field(4),
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export {
   TransferDynamicProofConfig,
   UpdatesDynamicProofConfig,
   DynamicProofConfig,
+  OperationKeys
 } from './configs.js';
 
 export { 

--- a/src/side-loaded/run.ts
+++ b/src/side-loaded/run.ts
@@ -19,6 +19,7 @@ import {
   BurnDynamicProofConfig,
   TransferDynamicProofConfig,
   UpdatesDynamicProofConfig,
+  OperationKeys,
 } from '../configs.js';
 import {
   program,
@@ -181,7 +182,7 @@ const updateVkeyTx = await Mina.transaction(
     fee,
   },
   async () => {
-    await token.updateSideLoadedVKeyHash(vKey, vKeyMap, Field(1));
+    await token.updateSideLoadedVKeyHash(vKey, vKeyMap, OperationKeys.Mint);
   }
 );
 await updateVkeyTx.prove();

--- a/src/test/approve.test.ts
+++ b/src/test/approve.test.ts
@@ -27,6 +27,7 @@ import {
   BurnDynamicProofConfig,
   TransferDynamicProofConfig,
   UpdatesDynamicProofConfig,
+  OperationKeys,
 } from '../configs.js';
 import {
   program,
@@ -39,7 +40,7 @@ import {
   PublicOutputs,
 } from '../side-loaded/program.eg.js';
 
-const proofsEnabled = false;
+const proofsEnabled = true;
 
 describe('New Token Standard ApproveBase Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;
@@ -582,7 +583,7 @@ describe('New Token Standard ApproveBase Tests', () => {
         user1,
         programVkey,
         vKeyMap,
-        Field(4),
+        OperationKeys.ApproveBase,
         [user1.key],
         expectedErrorMessage
       );
@@ -610,7 +611,7 @@ describe('New Token Standard ApproveBase Tests', () => {
         user1,
         programVkey,
         tamperedVKeyMap,
-        Field(4),
+        OperationKeys.ApproveBase,
         [user1.key, tokenAdmin.key],
         expectedErrorMessage
       );
@@ -632,11 +633,11 @@ describe('New Token Standard ApproveBase Tests', () => {
     });
 
     it('should update the side-loaded vKey hash for updates', async () => {
-      await updateSLVkeyHashTx(user1, programVkey, vKeyMap, Field(4), [
+      await updateSLVkeyHashTx(user1, programVkey, vKeyMap, OperationKeys.ApproveBase, [
         user1.key,
         tokenAdmin.key,
       ]);
-      vKeyMap.set(Field(4), programVkey.hash);
+      vKeyMap.set(OperationKeys.ApproveBase, programVkey.hash);
       expect(tokenContract.vKeyMapRoot.get()).toEqual(vKeyMap.root);
     });
   });
@@ -713,11 +714,11 @@ describe('New Token Standard ApproveBase Tests', () => {
     });
 
     it('should update the side-loaded vKey hash for updates to pause the method', async () => {
-      await updateSLVkeyHashTx(user1, pausedVkey, vKeyMap, Field(4), [
+      await updateSLVkeyHashTx(user1, pausedVkey, vKeyMap, OperationKeys.ApproveBase, [
         user1.key,
         tokenAdmin.key,
       ]);
-      vKeyMap.set(Field(4), pausedVkey.hash);
+      vKeyMap.set(OperationKeys.ApproveBase, pausedVkey.hash);
       expect(tokenContract.vKeyMapRoot.get()).toEqual(vKeyMap.root);
     });
 

--- a/src/test/burn.test.ts
+++ b/src/test/burn.test.ts
@@ -19,6 +19,7 @@ import {
   BurnDynamicProofConfig,
   TransferDynamicProofConfig,
   UpdatesDynamicProofConfig,
+  OperationKeys,
 } from '../configs.js';
 import {
   program,
@@ -29,7 +30,7 @@ import {
   program2,
 } from '../side-loaded/program.eg.js';
 
-const proofsEnabled = false;
+const proofsEnabled = true;
 
 describe('New Token Standard Burn Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;
@@ -517,7 +518,7 @@ describe('New Token Standard Burn Tests', () => {
         user1,
         programVkey,
         vKeyMap,
-        Field(2),
+        OperationKeys.Burn,
         [user1.key],
         expectedErrorMessage
       );
@@ -545,7 +546,7 @@ describe('New Token Standard Burn Tests', () => {
         user1,
         programVkey,
         tamperedVKeyMap,
-        Field(2),
+        OperationKeys.Burn,
         [user1.key, tokenAdmin.key],
         expectedErrorMessage
       );
@@ -567,11 +568,11 @@ describe('New Token Standard Burn Tests', () => {
     });
 
     it('should update the side-loaded vKey hash for burns', async () => {
-      await updateSLVkeyHashTx(user1, programVkey, vKeyMap, Field(2), [
+      await updateSLVkeyHashTx(user1, programVkey, vKeyMap, OperationKeys.Burn, [
         user1.key,
         tokenAdmin.key,
       ]);
-      vKeyMap.set(Field(2), programVkey.hash);
+      vKeyMap.set(OperationKeys.Burn, programVkey.hash);
       expect(tokenContract.vKeyMapRoot.get()).toEqual(vKeyMap.root);
     });
   });

--- a/src/test/mint.test.ts
+++ b/src/test/mint.test.ts
@@ -19,6 +19,7 @@ import {
   BurnDynamicProofConfig,
   TransferDynamicProofConfig,
   UpdatesDynamicProofConfig,
+  OperationKeys,
 } from '../configs.js';
 import {
   program,
@@ -30,7 +31,7 @@ import {
 } from '../side-loaded/program.eg.js';
 
 //! Tests can take up to 15 minutes with `proofsEnabled: true`, and around 4 minutes when false.
-const proofsEnabled = false;
+const proofsEnabled = true;
 
 describe('New Token Standard Mint Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;
@@ -565,7 +566,7 @@ describe('New Token Standard Mint Tests', () => {
         user1,
         programVkey,
         vKeyMap,
-        Field(1),
+        OperationKeys.Mint,
         [user1.key],
         expectedErrorMessage
       );
@@ -593,7 +594,7 @@ describe('New Token Standard Mint Tests', () => {
         user1,
         programVkey,
         tamperedVKeyMap,
-        Field(1),
+        OperationKeys.Mint,
         [user1.key, tokenAdmin.key],
         expectedErrorMessage
       );
@@ -615,11 +616,11 @@ describe('New Token Standard Mint Tests', () => {
     });
 
     it('should update the side-loaded vKey hash for mints', async () => {
-      await updateSLVkeyHashTx(user1, programVkey, vKeyMap, Field(1), [
+      await updateSLVkeyHashTx(user1, programVkey, vKeyMap, OperationKeys.Mint, [
         user1.key,
         tokenAdmin.key,
       ]);
-      vKeyMap.set(Field(1), programVkey.hash);
+      vKeyMap.set(OperationKeys.Mint, programVkey.hash);
       expect(tokenContract.vKeyMapRoot.get()).toEqual(vKeyMap.root);
     });
   });

--- a/src/test/transfer.test.ts
+++ b/src/test/transfer.test.ts
@@ -19,6 +19,7 @@ import {
   BurnDynamicProofConfig,
   TransferDynamicProofConfig,
   UpdatesDynamicProofConfig,
+  OperationKeys,
 } from '../configs.js';
 import {
   program,
@@ -29,7 +30,7 @@ import {
   program2,
 } from '../side-loaded/program.eg.js';
 
-const proofsEnabled = false;
+const proofsEnabled = true;
 
 describe('New Token Standard Transfer Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;
@@ -358,7 +359,7 @@ describe('New Token Standard Transfer Tests', () => {
         user1,
         programVkey,
         vKeyMap,
-        Field(3),
+        OperationKeys.Transfer,
         [user1.key],
         expectedErrorMessage
       );
@@ -386,7 +387,7 @@ describe('New Token Standard Transfer Tests', () => {
         user1,
         programVkey,
         tamperedVKeyMap,
-        Field(3),
+        OperationKeys.Transfer,
         [user1.key, tokenAdmin.key],
         expectedErrorMessage
       );
@@ -409,11 +410,11 @@ describe('New Token Standard Transfer Tests', () => {
     });
 
     it('should update the side-loaded vKey hash for transfers', async () => {
-      await updateSLVkeyHashTx(user1, programVkey, vKeyMap, Field(3), [
+      await updateSLVkeyHashTx(user1, programVkey, vKeyMap, OperationKeys.Transfer, [
         user1.key,
         tokenAdmin.key,
       ]);
-      vKeyMap.set(Field(3), programVkey.hash);
+      vKeyMap.set(OperationKeys.Transfer, programVkey.hash);
       expect(tokenContract.vKeyMapRoot.get()).toEqual(vKeyMap.root);
     });
   });


### PR DESCRIPTION
## Description
This PR replaces raw `Field(n)` values previously used as `operationKey` identifiers with named constants to improve clarity, reduce the risk of logical errors, and enhance maintainability.

## Changes:
- Introduced named constants for all supported operation keys (e.g., `OperationKey.Mint`, `OperationKey.Burn`)
- Updated all usages of `Field(n)` to use the appropriate named constant
- Ensured compatibility with existing `isValidOperationKey` validation
- Improved readability and intent-expression across relevant contract methods

Tests are passing with `proofsEnabled=true`