### PR TITLE
Emit Event on `VKeyMerkleMap` Updates

### DIFF
--- a/src/NewTokenStandard.ts
+++ b/src/NewTokenStandard.ts
@@ -47,6 +47,7 @@ export {
   BurnEvent,
   BalanceChangeEvent,
   VKeyMerkleMap,
+  SideLoadedVKeyUpdateEvent,
 };
 
 interface FungibleTokenDeployProps extends Exclude<DeployArgs, undefined> {
@@ -86,6 +87,7 @@ class FungibleToken extends TokenContract {
     Mint: MintEvent,
     Burn: BurnEvent,
     BalanceChange: BalanceChangeEvent,
+    SideLoadedVKeyUpdate: SideLoadedVKeyUpdateEvent,
   };
 
   private async ensureAdminSignature(condition: Bool) {
@@ -220,10 +222,21 @@ class FungibleToken extends TokenContract {
 
     isValidOperationKey.assertTrue('Please enter a valid operation key!');
 
+    const newVKeyHash = vKey.hash;
     vKeyMap = vKeyMap.clone();
-    vKeyMap.set(operationKey, vKey.hash);
+    vKeyMap.set(operationKey, newVKeyHash);
+    const newMerkleRoot = vKeyMap.root;
 
-    this.vKeyMapRoot.set(vKeyMap.root);
+    this.vKeyMapRoot.set(newMerkleRoot);
+
+    this.emitEvent(
+      'SideLoadedVKeyUpdate',
+      new SideLoadedVKeyUpdateEvent({
+        operationKey,
+        newVKeyHash,
+        newMerkleRoot,
+      })
+    );
   }
 
   @method
@@ -805,6 +818,12 @@ class BurnEvent extends Struct({
 class BalanceChangeEvent extends Struct({
   address: PublicKey,
   amount: Int64,
+}) {}
+
+class SideLoadedVKeyUpdateEvent extends Struct({
+  operationKey: Field,
+  newVKeyHash: Field,
+  newMerkleRoot: Field,
 }) {}
 
 // copied from: https://github.com/o1-labs/o1js/blob/6ebbc23710f6de023fea6d83dc93c5a914c571f2/src/lib/mina/token/token-contract.ts#L189

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export {
     MintEvent,
     BurnEvent,
     BalanceChangeEvent,
+    SideLoadedVKeyUpdateEvent,
     VKeyMerkleMap,
 } from './NewTokenStandard.js'
 


### PR DESCRIPTION
## Overview

This PR introduces event emission for updates to the side-loaded Verification Key Merkle Map to improve the traceability of verification key management.

## Changes
Contract (`src/NewTokenStandard.ts`)
- Defined a new event, `SideLoadedVKeyUpdateEvent`, which includes:
    - `operationKey: Field` (the key in the map being updated, e.g., for Mint, Burn)
    - `newVKeyHash: Field` (the new VKey hash being stored)
    - `newMerkleRoot: Field` (the new root of the `VKeyMerkleMap` after the update)
- Registered `SideLoadedVKeyUpdateEvent` in the contract's `events` property.
- The `updateSideLoadedVKeyHash` method now emits `SideLoadedVKeyUpdateEvent` upon successful modification of the on-chain `vKeyMapRoot`.
