### PR TITLE
Introduce Static Create Factory for Config-Aware Params Instantiation

### DIFF
--- a/src/configs.ts
+++ b/src/configs.ts
@@ -316,7 +316,7 @@ class MintParams extends AmountParams {
       initData = {
         fixedAmount: data.fixedAmount,
         minAmount: UInt64.from(0),
-        maxAmount: UInt64.from(1000),
+        maxAmount: UInt64.from(1),
       };
     } else {
       if (data.minAmount === undefined || data.maxAmount === undefined) {
@@ -330,7 +330,7 @@ class MintParams extends AmountParams {
         );
       }
       initData = {
-        fixedAmount: UInt64.from(200),
+        fixedAmount: UInt64.from(0),
         minAmount: data.minAmount,
         maxAmount: data.maxAmount,
       };
@@ -394,8 +394,8 @@ class BurnParams extends AmountParams {
       }
       initData = {
         fixedAmount: data.fixedAmount,
-        minAmount: UInt64.from(100),
-        maxAmount: UInt64.from(1500),
+        minAmount: UInt64.from(0),
+        maxAmount: UInt64.from(1),
       };
     } else {
       if (data.minAmount === undefined || data.maxAmount === undefined) {
@@ -409,7 +409,7 @@ class BurnParams extends AmountParams {
         );
       }
       initData = {
-        fixedAmount: UInt64.from(500),
+        fixedAmount: UInt64.from(0),
         minAmount: data.minAmount,
         maxAmount: data.maxAmount,
       };

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -298,7 +298,7 @@ class MintParams extends AmountParams {
     config: MintConfig,
     data: { fixedAmount?: UInt64; minAmount?: UInt64; maxAmount?: UInt64 }
   ): MintParams {
-    config.validate(); 
+    config.validate();
 
     let initData: { fixedAmount: UInt64; minAmount: UInt64; maxAmount: UInt64 };
 
@@ -316,9 +316,9 @@ class MintParams extends AmountParams {
       initData = {
         fixedAmount: data.fixedAmount,
         minAmount: UInt64.from(0),
-        maxAmount: UInt64.from(1000), 
+        maxAmount: UInt64.from(1000),
       };
-    } else { 
+    } else {
       if (data.minAmount === undefined || data.maxAmount === undefined) {
         throw new Error(
           'MintConfig requires a ranged amount, but `minAmount` or `maxAmount` was not provided in params data.'
@@ -343,11 +343,6 @@ class MintParams extends AmountParams {
     }
     return paramsInstance;
   }
-
-  static default = MintParams.create(MintConfig.default, {
-    minAmount: UInt64.from(0),
-    maxAmount: UInt64.from(1000),
-  });
 }
 
 /**
@@ -400,9 +395,9 @@ class BurnParams extends AmountParams {
       initData = {
         fixedAmount: data.fixedAmount,
         minAmount: UInt64.from(100),
-        maxAmount: UInt64.from(1500), 
+        maxAmount: UInt64.from(1500),
       };
-    } else { 
+    } else {
       if (data.minAmount === undefined || data.maxAmount === undefined) {
         throw new Error(
           'BurnConfig requires a ranged amount, but `minAmount` or `maxAmount` was not provided in params data.'
@@ -427,11 +422,6 @@ class BurnParams extends AmountParams {
     }
     return paramsInstance;
   }
-
-  static default = BurnParams.create(BurnConfig.default, {
-    minAmount: UInt64.from(100),
-    maxAmount: UInt64.from(1500),
-  });
 }
 
 /**

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -334,13 +334,13 @@ class MintParams extends AmountParams {
         minAmount: data.minAmount,
         maxAmount: data.maxAmount,
       };
+      initData.minAmount.assertLessThan(
+        initData.maxAmount,
+        'Invalid amount range!'
+      );
     }
 
     const paramsInstance = new MintParams(initData);
-
-    if (config.rangedAmount.toBoolean()) {
-      paramsInstance.validate();
-    }
     return paramsInstance;
   }
 }
@@ -413,13 +413,13 @@ class BurnParams extends AmountParams {
         minAmount: data.minAmount,
         maxAmount: data.maxAmount,
       };
+      initData.minAmount.assertLessThan(
+        initData.maxAmount,
+        'Invalid amount range!'
+      );
     }
 
     const paramsInstance = new BurnParams(initData);
-
-    if (config.rangedAmount.toBoolean()) {
-      paramsInstance.validate();
-    }
     return paramsInstance;
   }
 }

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -272,7 +272,83 @@ class AmountParams extends Struct({
  * Inherits all behavior from {@link AmountParams}, including serialization,
  * deserialization, and range validation.
  */
-class MintParams extends AmountParams {}
+class MintParams extends AmountParams {
+  /**
+   * Creates a new `MintParams` instance, ensuring consistency with the provided `MintConfig`.
+   *
+   * This factory method validates the `MintConfig` and initializes the `MintParams`
+   * fields (`fixedAmount`, `minAmount`, `maxAmount`) based on whether the config
+   * specifies a fixed or ranged amount minting.
+   *
+   * - If `config.fixedAmount` is true, `data.fixedAmount` is used, and `minAmount`/`maxAmount`
+   *   are set to 0 and 1 respectively (to pass `AmountParams.validate` if called).
+   * - If `config.rangedAmount` is true, `data.minAmount` and `data.maxAmount` are used,
+   *   and `fixedAmount` is set to 0.
+   *
+   * @param config - The `MintConfig` to adhere to.
+   * @param data - An object containing the amount values.
+   *   - `fixedAmount` (optional): The amount for fixed-amount minting. Required if `config.fixedAmount` is true.
+   *   - `minAmount` (optional): The minimum amount for ranged-amount minting. Required if `config.rangedAmount` is true.
+   *   - `maxAmount` (optional): The maximum amount for ranged-amount minting. Required if `config.rangedAmount` is true.
+   * @returns A new `MintParams` instance.
+   * @throws If `config` is invalid (e.g., both fixed and ranged are true).
+   * @throws If required `data` fields are missing for the specified config mode.
+   */
+  static create(
+    config: MintConfig,
+    data: { fixedAmount?: UInt64; minAmount?: UInt64; maxAmount?: UInt64 }
+  ): MintParams {
+    config.validate(); 
+
+    let initData: { fixedAmount: UInt64; minAmount: UInt64; maxAmount: UInt64 };
+
+    if (config.fixedAmount.toBoolean()) {
+      if (data.fixedAmount === undefined) {
+        throw new Error(
+          'MintConfig requires a fixed amount, but no `fixedAmount` was provided in params data.'
+        );
+      }
+      if (data.minAmount !== undefined || data.maxAmount !== undefined) {
+        throw new Error(
+          'MintConfig requires a fixed amount; `minAmount` and `maxAmount` should not be provided in params data.'
+        );
+      }
+      initData = {
+        fixedAmount: data.fixedAmount,
+        minAmount: UInt64.from(0),
+        maxAmount: UInt64.from(1000), 
+      };
+    } else { 
+      if (data.minAmount === undefined || data.maxAmount === undefined) {
+        throw new Error(
+          'MintConfig requires a ranged amount, but `minAmount` or `maxAmount` was not provided in params data.'
+        );
+      }
+      if (data.fixedAmount !== undefined) {
+        throw new Error(
+          'MintConfig requires a ranged amount; `fixedAmount` should not be provided in params data.'
+        );
+      }
+      initData = {
+        fixedAmount: UInt64.from(200),
+        minAmount: data.minAmount,
+        maxAmount: data.maxAmount,
+      };
+    }
+
+    const paramsInstance = new MintParams(initData);
+
+    if (config.rangedAmount.toBoolean()) {
+      paramsInstance.validate();
+    }
+    return paramsInstance;
+  }
+
+  static default = MintParams.create(MintConfig.default, {
+    minAmount: UInt64.from(0),
+    maxAmount: UInt64.from(1000),
+  });
+}
 
 /**
  * `BurnParams` defines the parameters for token burning.
@@ -280,7 +356,83 @@ class MintParams extends AmountParams {}
  * Inherits all behavior from {@link AmountParams}, including serialization,
  * deserialization, and range validation.
  */
-class BurnParams extends AmountParams {}
+class BurnParams extends AmountParams {
+  /**
+   * Creates a new `BurnParams` instance, ensuring consistency with the provided `BurnConfig`.
+   *
+   * This factory method validates the `BurnConfig` and initializes the `BurnParams`
+   * fields (`fixedAmount`, `minAmount`, `maxAmount`) based on whether the config
+   * specifies a fixed or ranged amount burning.
+   *
+   * - If `config.fixedAmount` is true, `data.fixedAmount` is used, and `minAmount`/`maxAmount`
+   *   are set to 0 and 1 respectively (to pass `AmountParams.validate` if called).
+   * - If `config.rangedAmount` is true, `data.minAmount` and `data.maxAmount` are used,
+   *   and `fixedAmount` is set to 0.
+   *
+   * @param config - The `BurnConfig` to adhere to.
+   * @param data - An object containing the amount values.
+   *   - `fixedAmount` (optional): The amount for fixed-amount burning. Required if `config.fixedAmount` is true.
+   *   - `minAmount` (optional): The minimum amount for ranged-amount burning. Required if `config.rangedAmount` is true.
+   *   - `maxAmount` (optional): The maximum amount for ranged-amount burning. Required if `config.rangedAmount` is true.
+   * @returns A new `BurnParams` instance.
+   * @throws If `config` is invalid (e.g., both fixed and ranged are true).
+   * @throws If required `data` fields are missing for the specified config mode.
+   */
+  static create(
+    config: BurnConfig,
+    data: { fixedAmount?: UInt64; minAmount?: UInt64; maxAmount?: UInt64 }
+  ): BurnParams {
+    config.validate();
+
+    let initData: { fixedAmount: UInt64; minAmount: UInt64; maxAmount: UInt64 };
+
+    if (config.fixedAmount.toBoolean()) {
+      if (data.fixedAmount === undefined) {
+        throw new Error(
+          'BurnConfig requires a fixed amount, but no `fixedAmount` was provided in params data.'
+        );
+      }
+      if (data.minAmount !== undefined || data.maxAmount !== undefined) {
+        throw new Error(
+          'BurnConfig requires a fixed amount; `minAmount` and `maxAmount` should not be provided in params data.'
+        );
+      }
+      initData = {
+        fixedAmount: data.fixedAmount,
+        minAmount: UInt64.from(100),
+        maxAmount: UInt64.from(1500), 
+      };
+    } else { 
+      if (data.minAmount === undefined || data.maxAmount === undefined) {
+        throw new Error(
+          'BurnConfig requires a ranged amount, but `minAmount` or `maxAmount` was not provided in params data.'
+        );
+      }
+      if (data.fixedAmount !== undefined) {
+        throw new Error(
+          'BurnConfig requires a ranged amount; `fixedAmount` should not be provided in params data.'
+        );
+      }
+      initData = {
+        fixedAmount: UInt64.from(500),
+        minAmount: data.minAmount,
+        maxAmount: data.maxAmount,
+      };
+    }
+
+    const paramsInstance = new BurnParams(initData);
+
+    if (config.rangedAmount.toBoolean()) {
+      paramsInstance.validate();
+    }
+    return paramsInstance;
+  }
+
+  static default = BurnParams.create(BurnConfig.default, {
+    minAmount: UInt64.from(100),
+    maxAmount: UInt64.from(1500),
+  });
+}
 
 /**
  * `DynamicProofConfig` defines a generic configuration to control and verify constraints for side-loaded proofs in token operations.

--- a/src/examples/concurrent-transfer.new.eg.ts
+++ b/src/examples/concurrent-transfer.new.eg.ts
@@ -114,13 +114,14 @@ const dummyProof: SideloadedProof = await generateDummyDynamicProof(
   alexa.publicKey
 );
 
-const mintParams = new MintParams({
-  fixedAmount: UInt64.from(0),
+const mintConfig = MintConfig.default;
+const burnConfig = BurnConfig.default;
+
+const mintParams = MintParams.create(MintConfig.default, {
   minAmount: UInt64.from(1),
   maxAmount: UInt64.from(100e9),
 });
-const burnParams = new BurnParams({
-  fixedAmount: UInt64.from(0),
+const burnParams = BurnParams.create(BurnConfig.default, {
   minAmount: UInt64.from(1),
   maxAmount: UInt64.from(100e9),
 });
@@ -142,9 +143,9 @@ const deployTx = await Mina.transaction(
     await token.initialize(
       admin.publicKey,
       UInt8.from(9),
-      MintConfig.default,
+      mintConfig,
       mintParams,
-      BurnConfig.default,
+      burnConfig,
       burnParams,
       MintDynamicProofConfig.default,
       BurnDynamicProofConfig.default,

--- a/src/examples/concurrent-transfer.new.eg.ts
+++ b/src/examples/concurrent-transfer.new.eg.ts
@@ -114,9 +114,6 @@ const dummyProof: SideloadedProof = await generateDummyDynamicProof(
   alexa.publicKey
 );
 
-const mintConfig = MintConfig.default;
-const burnConfig = BurnConfig.default;
-
 const mintParams = MintParams.create(MintConfig.default, {
   minAmount: UInt64.from(1),
   maxAmount: UInt64.from(100e9),
@@ -143,9 +140,9 @@ const deployTx = await Mina.transaction(
     await token.initialize(
       admin.publicKey,
       UInt8.from(9),
-      mintConfig,
+      MintConfig.default,
       mintParams,
-      burnConfig,
+      BurnConfig.default,
       burnParams,
       MintDynamicProofConfig.default,
       BurnDynamicProofConfig.default,

--- a/src/examples/e2e.new.eg.ts
+++ b/src/examples/e2e.new.eg.ts
@@ -29,16 +29,8 @@ const [deployer, owner, admin, alexa, billy] = localChain.testAccounts;
 const contract = PrivateKey.randomKeypair();
 const token = new FungibleToken(contract.publicKey);
 
-const mintParams = new MintParams({
-  fixedAmount: UInt64.from(200),
-  minAmount: UInt64.from(1),
-  maxAmount: UInt64.from(1000),
-});
-const burnParams = new BurnParams({
-  fixedAmount: UInt64.from(500),
-  minAmount: UInt64.from(100),
-  maxAmount: UInt64.from(1500),
-});
+const mintParams = MintParams.default;
+const burnParams = BurnParams.default;
 
 console.log('Deploying token contract.');
 const deployTx = await Mina.transaction(

--- a/src/examples/e2e.new.eg.ts
+++ b/src/examples/e2e.new.eg.ts
@@ -29,8 +29,14 @@ const [deployer, owner, admin, alexa, billy] = localChain.testAccounts;
 const contract = PrivateKey.randomKeypair();
 const token = new FungibleToken(contract.publicKey);
 
-const mintParams = MintParams.default;
-const burnParams = BurnParams.default;
+const mintParams = MintParams.create(MintConfig.default, {
+  minAmount: UInt64.from(1),
+  maxAmount: UInt64.from(1000),
+});
+const burnParams = BurnParams.create(BurnConfig.default, {
+  minAmount: UInt64.from(100),
+  maxAmount: UInt64.from(1500),
+});
 
 console.log('Deploying token contract.');
 const deployTx = await Mina.transaction(

--- a/src/examples/escrow.new.eg.ts
+++ b/src/examples/escrow.new.eg.ts
@@ -127,8 +127,14 @@ TokenContract Public Key: ${escrowContractKeyPair.publicKey.toBase58()}
 EscrowContract Public Key: ${escrowContractKeyPair.publicKey.toBase58()}
 `);
 
-const mintParams = MintParams.default;
-const burnParams = BurnParams.default;
+const mintParams = MintParams.create(MintConfig.default, {
+  minAmount: UInt64.from(1),
+  maxAmount: UInt64.from(1000),
+});
+const burnParams = BurnParams.create(BurnConfig.default, {
+  minAmount: UInt64.from(100),
+  maxAmount: UInt64.from(1500),
+});
 
 const tokenContract = new FungibleToken(tokenContractKeyPair.publicKey);
 const tokenId = tokenContract.deriveTokenId();

--- a/src/examples/escrow.new.eg.ts
+++ b/src/examples/escrow.new.eg.ts
@@ -127,16 +127,8 @@ TokenContract Public Key: ${escrowContractKeyPair.publicKey.toBase58()}
 EscrowContract Public Key: ${escrowContractKeyPair.publicKey.toBase58()}
 `);
 
-const mintParams = new MintParams({
-  fixedAmount: UInt64.from(200),
-  minAmount: UInt64.from(1),
-  maxAmount: UInt64.from(1000),
-});
-const burnParams = new BurnParams({
-  fixedAmount: UInt64.from(500),
-  minAmount: UInt64.from(100),
-  maxAmount: UInt64.from(1500),
-});
+const mintParams = MintParams.default;
+const burnParams = BurnParams.default;
 
 const tokenContract = new FungibleToken(tokenContractKeyPair.publicKey);
 const tokenId = tokenContract.deriveTokenId();

--- a/src/run.ts
+++ b/src/run.ts
@@ -37,17 +37,8 @@ const dummyProof = await generateDummyDynamicProof(
   alexa
 );
 
-const mintParams = new MintParams({
-  fixedAmount: UInt64.from(200),
-  minAmount: UInt64.from(0),
-  maxAmount: UInt64.from(1000),
-});
-
-const burnParams = new BurnParams({
-  fixedAmount: UInt64.from(500),
-  minAmount: UInt64.from(100),
-  maxAmount: UInt64.from(1500),
-});
+const mintParams = MintParams.default;
+const burnParams = BurnParams.default;
 
 // ----------------------- DEPLOY --------------------------------
 console.log('Deploying token contract.');

--- a/src/run.ts
+++ b/src/run.ts
@@ -37,8 +37,14 @@ const dummyProof = await generateDummyDynamicProof(
   alexa
 );
 
-const mintParams = MintParams.default;
-const burnParams = BurnParams.default;
+const mintParams = MintParams.create(MintConfig.default, {
+  minAmount: UInt64.from(0),
+  maxAmount: UInt64.from(1000),
+});
+const burnParams = BurnParams.create(BurnConfig.default, {
+  minAmount: UInt64.from(100),
+  maxAmount: UInt64.from(1500),
+});
 
 // ----------------------- DEPLOY --------------------------------
 console.log('Deploying token contract.');

--- a/src/side-loaded/run.ts
+++ b/src/side-loaded/run.ts
@@ -52,8 +52,14 @@ Provable.log('Program verification key: ', vKey.hash);
 
 let vKeyMap = new VKeyMerkleMap();
 
-const mintParams = MintParams.default;
-const burnParams = BurnParams.default;
+const mintParams = MintParams.create(MintConfig.default, {
+  minAmount: UInt64.from(0),
+  maxAmount: UInt64.from(1000),
+});
+const burnParams = BurnParams.create(BurnConfig.default, {
+  minAmount: UInt64.from(100),
+  maxAmount: UInt64.from(1500),
+});
 
 // ----------------------- DEPLOY --------------------------------
 console.log('Deploying token contract.');

--- a/src/side-loaded/run.ts
+++ b/src/side-loaded/run.ts
@@ -52,17 +52,8 @@ Provable.log('Program verification key: ', vKey.hash);
 
 let vKeyMap = new VKeyMerkleMap();
 
-const mintParams = new MintParams({
-  fixedAmount: UInt64.from(200),
-  minAmount: UInt64.from(0),
-  maxAmount: UInt64.from(1000),
-});
-
-const burnParams = new BurnParams({
-  fixedAmount: UInt64.from(500),
-  minAmount: UInt64.from(100),
-  maxAmount: UInt64.from(1500),
-});
+const mintParams = MintParams.default;
+const burnParams = BurnParams.default;
 
 // ----------------------- DEPLOY --------------------------------
 console.log('Deploying token contract.');

--- a/src/test/approve.test.ts
+++ b/src/test/approve.test.ts
@@ -39,7 +39,7 @@ import {
   PublicOutputs,
 } from '../side-loaded/program.eg.js';
 
-const proofsEnabled = true;
+const proofsEnabled = false;
 
 describe('New Token Standard ApproveBase Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;

--- a/src/test/approve.test.ts
+++ b/src/test/approve.test.ts
@@ -75,17 +75,8 @@ describe('New Token Standard ApproveBase Tests', () => {
     [deployer, user1, user2, user3] = localChain.testAccounts;
     tokenContract = new FungibleToken(tokenA);
 
-    mintParams = new MintParams({
-      fixedAmount: UInt64.from(200),
-      minAmount: UInt64.from(0),
-      maxAmount: UInt64.from(1000),
-    });
-
-    burnParams = new BurnParams({
-      fixedAmount: UInt64.from(100),
-      minAmount: UInt64.from(50),
-      maxAmount: UInt64.from(500),
-    });
+    mintParams = MintParams.default;
+    burnParams = BurnParams.default;
 
     vKeyMap = new VKeyMerkleMap();
     dummyVkey = await VerificationKey.dummy();

--- a/src/test/approve.test.ts
+++ b/src/test/approve.test.ts
@@ -39,7 +39,7 @@ import {
   PublicOutputs,
 } from '../side-loaded/program.eg.js';
 
-const proofsEnabled = false;
+const proofsEnabled = true;
 
 describe('New Token Standard ApproveBase Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;
@@ -75,8 +75,15 @@ describe('New Token Standard ApproveBase Tests', () => {
     [deployer, user1, user2, user3] = localChain.testAccounts;
     tokenContract = new FungibleToken(tokenA);
 
-    mintParams = MintParams.default;
-    burnParams = BurnParams.default;
+    mintParams = MintParams.create(MintConfig.default, {
+      minAmount: UInt64.from(0),
+      maxAmount: UInt64.from(1000),
+    });
+
+    burnParams = BurnParams.create(BurnConfig.default, {
+      minAmount: UInt64.from(50),
+      maxAmount: UInt64.from(500),
+    });
 
     vKeyMap = new VKeyMerkleMap();
     dummyVkey = await VerificationKey.dummy();

--- a/src/test/burn.test.ts
+++ b/src/test/burn.test.ts
@@ -29,7 +29,7 @@ import {
   program2,
 } from '../side-loaded/program.eg.js';
 
-const proofsEnabled = true;
+const proofsEnabled = false;
 
 describe('New Token Standard Burn Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;

--- a/src/test/burn.test.ts
+++ b/src/test/burn.test.ts
@@ -63,17 +63,8 @@ describe('New Token Standard Burn Tests', () => {
     [deployer, user1, user2] = localChain.testAccounts;
     tokenContract = new FungibleToken(tokenA);
 
-    mintParams = new MintParams({
-      fixedAmount: UInt64.from(200),
-      minAmount: UInt64.from(0),
-      maxAmount: UInt64.from(1000),
-    });
-
-    burnParams = new BurnParams({
-      fixedAmount: UInt64.from(100),
-      minAmount: UInt64.from(50),
-      maxAmount: UInt64.from(500),
-    });
+    mintParams = MintParams.default;
+    burnParams = BurnParams.default;
 
     vKeyMap = new VKeyMerkleMap();
     dummyVkey = await VerificationKey.dummy();

--- a/src/test/burn.test.ts
+++ b/src/test/burn.test.ts
@@ -29,7 +29,7 @@ import {
   program2,
 } from '../side-loaded/program.eg.js';
 
-const proofsEnabled = false;
+const proofsEnabled = true;
 
 describe('New Token Standard Burn Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;
@@ -63,8 +63,15 @@ describe('New Token Standard Burn Tests', () => {
     [deployer, user1, user2] = localChain.testAccounts;
     tokenContract = new FungibleToken(tokenA);
 
-    mintParams = MintParams.default;
-    burnParams = BurnParams.default;
+    mintParams = MintParams.create(MintConfig.default, {
+      minAmount: UInt64.from(0),
+      maxAmount: UInt64.from(1000),
+    });
+
+    burnParams = BurnParams.create(BurnConfig.default, {
+      minAmount: UInt64.from(50),
+      maxAmount: UInt64.from(500),
+    });
 
     vKeyMap = new VKeyMerkleMap();
     dummyVkey = await VerificationKey.dummy();

--- a/src/test/mint.test.ts
+++ b/src/test/mint.test.ts
@@ -30,7 +30,7 @@ import {
 } from '../side-loaded/program.eg.js';
 
 //! Tests can take up to 15 minutes with `proofsEnabled: true`, and around 4 minutes when false.
-const proofsEnabled = true;
+const proofsEnabled = false;
 
 describe('New Token Standard Mint Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;

--- a/src/test/mint.test.ts
+++ b/src/test/mint.test.ts
@@ -30,7 +30,7 @@ import {
 } from '../side-loaded/program.eg.js';
 
 //! Tests can take up to 15 minutes with `proofsEnabled: true`, and around 4 minutes when false.
-const proofsEnabled = false;
+const proofsEnabled = true;
 
 describe('New Token Standard Mint Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;
@@ -64,8 +64,15 @@ describe('New Token Standard Mint Tests', () => {
     [deployer, user1, user2] = localChain.testAccounts;
     tokenContract = new FungibleToken(tokenA);
 
-    mintParams = MintParams.default;
-    burnParams = BurnParams.default;
+    mintParams = MintParams.create(MintConfig.default, {
+      minAmount: UInt64.from(0),
+      maxAmount: UInt64.from(1000),
+    });
+
+    burnParams = BurnParams.create(BurnConfig.default, {
+      minAmount: UInt64.from(100),
+      maxAmount: UInt64.from(1500),
+    });
 
     vKeyMap = new VKeyMerkleMap();
     dummyVkey = await VerificationKey.dummy();

--- a/src/test/mint.test.ts
+++ b/src/test/mint.test.ts
@@ -64,17 +64,8 @@ describe('New Token Standard Mint Tests', () => {
     [deployer, user1, user2] = localChain.testAccounts;
     tokenContract = new FungibleToken(tokenA);
 
-    mintParams = new MintParams({
-      fixedAmount: UInt64.from(200),
-      minAmount: UInt64.from(0),
-      maxAmount: UInt64.from(1000),
-    });
-
-    burnParams = new BurnParams({
-      fixedAmount: UInt64.from(500),
-      minAmount: UInt64.from(100),
-      maxAmount: UInt64.from(1500),
-    });
+    mintParams = MintParams.default;
+    burnParams = BurnParams.default;
 
     vKeyMap = new VKeyMerkleMap();
     dummyVkey = await VerificationKey.dummy();

--- a/src/test/transfer.test.ts
+++ b/src/test/transfer.test.ts
@@ -64,17 +64,8 @@ describe('New Token Standard Transfer Tests', () => {
     [deployer, user1, user2, user3] = localChain.testAccounts;
     tokenContract = new FungibleToken(tokenA);
 
-    mintParams = new MintParams({
-      fixedAmount: UInt64.from(200),
-      minAmount: UInt64.from(0),
-      maxAmount: UInt64.from(1000),
-    });
-
-    burnParams = new BurnParams({
-      fixedAmount: UInt64.from(100),
-      minAmount: UInt64.from(50),
-      maxAmount: UInt64.from(500),
-    });
+    mintParams = MintParams.default;
+    burnParams = BurnParams.default;
 
     vKeyMap = new VKeyMerkleMap();
     dummyVkey = await VerificationKey.dummy();

--- a/src/test/transfer.test.ts
+++ b/src/test/transfer.test.ts
@@ -29,7 +29,7 @@ import {
   program2,
 } from '../side-loaded/program.eg.js';
 
-const proofsEnabled = true;
+const proofsEnabled = false;
 
 describe('New Token Standard Transfer Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;

--- a/src/test/transfer.test.ts
+++ b/src/test/transfer.test.ts
@@ -29,7 +29,7 @@ import {
   program2,
 } from '../side-loaded/program.eg.js';
 
-const proofsEnabled = false;
+const proofsEnabled = true;
 
 describe('New Token Standard Transfer Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;
@@ -64,8 +64,15 @@ describe('New Token Standard Transfer Tests', () => {
     [deployer, user1, user2, user3] = localChain.testAccounts;
     tokenContract = new FungibleToken(tokenA);
 
-    mintParams = MintParams.default;
-    burnParams = BurnParams.default;
+    mintParams = MintParams.create(MintConfig.default, {
+      minAmount: UInt64.from(0),
+      maxAmount: UInt64.from(1000),
+    });
+
+    burnParams = BurnParams.create(BurnConfig.default, {
+      minAmount: UInt64.from(50),
+      maxAmount: UInt64.from(500),
+    });
 
     vKeyMap = new VKeyMerkleMap();
     dummyVkey = await VerificationKey.dummy();


### PR DESCRIPTION
## Description

This PR refactors the `MintParams` and `BurnParams` classes to improve developer experience when creating parameter instances that depend on `MintConfig` or `BurnConfig`.

Previously, developers had to manually ensure that the `fixedAmount`, `minAmount`, and `maxAmount` fields in `MintParams` and `BurnParams` were consistent with the corresponding `MintConfig` or `BurnConfig` (i.e., whether the config was for a fixed or ranged amount). This could lead to runtime errors if not handled correctly, particularly with the `AmountParams.validate()` method which unconditionally checks `minAmount < maxAmount`.

This refactor introduces:

1.  **`static create(config, data)` factory methods** on `MintParams` and `BurnParams`.
    *   These methods take a `Config` object (`MintConfig` or `BurnConfig`) and a `data` object containing the relevant amount(s) (`fixedAmount` or `minAmount`/`maxAmount`).
    *   They validate the provided `config`.
    *   They initialize the `Params` instance correctly based on the `config`'s mode (fixed or ranged):
        *   For **fixed mode**, `data.fixedAmount` is used.
        *   For **ranged mode**, `data.minAmount` and `data.maxAmount` are used. The standard `AmountParams.validate()` is called to check the range.
    *   This centralizes the logic for creating config-aware `Params` instances, making it less error-prone for developers.
2.  The `Struct`-generated constructor (`new MintParams({...})`) is now primarily intended for internal use (e.g., by `AmountParams.unpack`) or for specific test scenarios where direct, non-config-aware instantiation is required.

## Changes

*   **`src/configs.ts`**:
    *   Added `static create()` methods to `MintParams` and `BurnParams`.
    *   Removed custom constructor logic from `MintParams` and `BurnParams`, deferring to the `Struct` constructor.
    *   Added JSDoc comments for the new factory methods.
*   **Test Files** (`src/test/*.test.ts`):
    *   Updated instantiations of `MintParams` and `BurnParams` in `beforeAll` blocks and other relevant places to use the new `create()` factory method for config-aware setups.
    *   Direct instantiations (`new MintParams(...)`) are preserved where necessary for testing invalid states or specific `initialize` method parameters.
*   **Example Files and Run Scripts** (`src/examples/*.eg.ts`, `src/run.ts`, `src/side-loaded/run.ts`):
    *   Updated to use the new `create()` factory method for instantiating `MintParams` and `BurnParams`.