### PR TITLE
Add Field-Specific Update Methods for Mint/Burn Params and Configs

### DIFF
--- a/src/NewTokenStandard.ts
+++ b/src/NewTokenStandard.ts
@@ -801,6 +801,128 @@ class FungibleToken extends TokenContract {
     // Conditionally verify the provided side-loaded proof.
     proof.verifyIf(vk, shouldVerify);
   }
+
+  @method
+  async updateMintFixedAmount(value: UInt64) {
+    this.ensureAdminSignature(Bool(true));
+    const packedMintParams = this.packedMintParams.getAndRequireEquals();
+    const params = MintParams.unpack(packedMintParams);
+    params.fixedAmount = value;
+    this.packedMintParams.set(params.pack());
+  }
+
+  @method
+  async updateMintMinAmount(value: UInt64) {
+    this.ensureAdminSignature(Bool(true));
+    const packedMintParams = this.packedMintParams.getAndRequireEquals();
+    const params = MintParams.unpack(packedMintParams);
+    params.minAmount = value;
+    params.validate();
+    this.packedMintParams.set(params.pack());
+  }
+
+  @method
+  async updateMintMaxAmount(value: UInt64) {
+    this.ensureAdminSignature(Bool(true));
+    const packedMintParams = this.packedMintParams.getAndRequireEquals();
+    const params = MintParams.unpack(packedMintParams);
+    params.maxAmount = value;
+    params.validate();
+    this.packedMintParams.set(params.pack());
+  }
+
+  @method
+  async updateBurnFixedAmount(value: UInt64) {
+    this.ensureAdminSignature(Bool(true));
+    const packedBurnParams = this.packedBurnParams.getAndRequireEquals();
+    const params = BurnParams.unpack(packedBurnParams);
+    params.fixedAmount = value;
+    this.packedBurnParams.set(params.pack());
+  }
+
+  @method
+  async updateBurnMinAmount(value: UInt64) {
+    this.ensureAdminSignature(Bool(true));
+    const packedBurnParams = this.packedBurnParams.getAndRequireEquals();
+    const params = BurnParams.unpack(packedBurnParams);
+    params.minAmount = value;
+    params.validate();
+    this.packedBurnParams.set(params.pack());
+  }
+
+  @method
+  async updateBurnMaxAmount(value: UInt64) {
+    this.ensureAdminSignature(Bool(true));
+    const packedBurnParams = this.packedBurnParams.getAndRequireEquals();
+    const params = BurnParams.unpack(packedBurnParams);
+    params.maxAmount = value;
+    params.validate();
+    this.packedBurnParams.set(params.pack());
+  }
+
+  @method
+  async updateMintFixedAmountConfig(value: Bool) {
+    this.ensureAdminSignature(Bool(true));
+    const packedConfigs = this.packedAmountConfigs.getAndRequireEquals();
+    const config = MintConfig.unpack(packedConfigs);
+    config.fixedAmount = value;
+    config.rangedAmount = value.not();
+    config.validate();
+    this.packedAmountConfigs.set(config.updatePackedConfigs(packedConfigs));
+  }
+
+  @method
+  async updateMintRangedAmountConfig(value: Bool) {
+    this.ensureAdminSignature(Bool(true));
+    const packedConfigs = this.packedAmountConfigs.getAndRequireEquals();
+    const config = MintConfig.unpack(packedConfigs);
+    config.rangedAmount = value;
+    config.fixedAmount = value.not();
+    config.validate();
+    this.packedAmountConfigs.set(config.updatePackedConfigs(packedConfigs));
+  }
+
+  @method
+  async updateMintUnauthorizedConfig(value: Bool) {
+    this.ensureAdminSignature(Bool(true));
+    const packedConfigs = this.packedAmountConfigs.getAndRequireEquals();
+    const config = MintConfig.unpack(packedConfigs);
+    config.unauthorized = value;
+    config.validate();
+    this.packedAmountConfigs.set(config.updatePackedConfigs(packedConfigs));
+  }
+
+  @method
+  async updateBurnFixedAmountConfig(value: Bool) {
+    this.ensureAdminSignature(Bool(true));
+    const packedConfigs = this.packedAmountConfigs.getAndRequireEquals();
+    const config = BurnConfig.unpack(packedConfigs);
+    config.fixedAmount = value;
+    config.rangedAmount = value.not();
+    config.validate();
+    this.packedAmountConfigs.set(config.updatePackedConfigs(packedConfigs));
+  }
+
+  @method
+  async updateBurnRangedAmountConfig(value: Bool) {
+    this.ensureAdminSignature(Bool(true));
+    const packedConfigs = this.packedAmountConfigs.getAndRequireEquals();
+    const config = BurnConfig.unpack(packedConfigs);
+    config.rangedAmount = value;
+    config.fixedAmount = value.not();
+    config.validate();
+    this.packedAmountConfigs.set(config.updatePackedConfigs(packedConfigs));
+  }
+
+  @method
+  async updateBurnUnauthorizedConfig(value: Bool) {
+    this.ensureAdminSignature(Bool(true));
+    const packedConfigs = this.packedAmountConfigs.getAndRequireEquals();
+    const config = BurnConfig.unpack(packedConfigs);
+    config.unauthorized = value;
+    config.validate();
+    this.packedAmountConfigs.set(config.updatePackedConfigs(packedConfigs));
+  }
 }
 
 class SetAdminEvent extends Struct({

--- a/src/test/approve.test.ts
+++ b/src/test/approve.test.ts
@@ -40,7 +40,7 @@ import {
   PublicOutputs,
 } from '../side-loaded/program.eg.js';
 
-const proofsEnabled = true;
+const proofsEnabled = false;
 
 describe('New Token Standard ApproveBase Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;

--- a/src/test/burn.test.ts
+++ b/src/test/burn.test.ts
@@ -1065,10 +1065,13 @@ describe('New Token Standard Burn Tests', () => {
     });
 
     it('should update the side-loaded vKey hash for burns', async () => {
-      await updateSLVkeyHashTx(user1, programVkey, vKeyMap, OperationKeys.Burn, [
-        user1.key,
-        tokenAdmin.key,
-      ]);
+      await updateSLVkeyHashTx(
+        user1,
+        programVkey,
+        vKeyMap,
+        OperationKeys.Burn,
+        [user1.key, tokenAdmin.key]
+      );
       vKeyMap.set(OperationKeys.Burn, programVkey.hash);
       expect(tokenContract.vKeyMapRoot.get()).toEqual(vKeyMap.root);
     });

--- a/src/test/burn.test.ts
+++ b/src/test/burn.test.ts
@@ -30,7 +30,7 @@ import {
   program2,
 } from '../side-loaded/program.eg.js';
 
-const proofsEnabled = true;
+const proofsEnabled = false;
 
 describe('New Token Standard Burn Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;

--- a/src/test/burn.test.ts
+++ b/src/test/burn.test.ts
@@ -704,9 +704,9 @@ describe('New Token Standard Burn Tests', () => {
 
     it('should reject burnParams update when unauthorized by the admin', async () => {
       burnParams = new BurnParams({
-        fixedAmount: UInt64.from(150),
-        minAmount: UInt64.from(100),
-        maxAmount: UInt64.from(850),
+        fixedAmount: UInt64.from(100),
+        minAmount: UInt64.from(50),
+        maxAmount: UInt64.from(600),
       });
 
       const expectedErrorMessage =
@@ -721,6 +721,198 @@ describe('New Token Standard Burn Tests', () => {
 
     it('should update packed burnParams', async () => {
       await updateBurnParamsTx(user1, burnParams, [user1.key, tokenAdmin.key]);
+    });
+
+    it('should update burn fixed amount via field-specific function', async () => {
+      const newFixedAmount = UInt64.from(150);
+      await updateBurnFixedAmountTx(user1, newFixedAmount, [
+        user1.key,
+        tokenAdmin.key,
+      ]);
+
+      const paramsAfterUpdate = BurnParams.unpack(
+        tokenContract.packedBurnParams.get()
+      );
+      expect(paramsAfterUpdate.fixedAmount).toEqual(newFixedAmount);
+      expect(paramsAfterUpdate.minAmount).toEqual(burnParams.minAmount);
+      expect(paramsAfterUpdate.maxAmount).toEqual(burnParams.maxAmount);
+    });
+
+    it('should reject burn fixed amount update via field-specific function when unauthorized by the admin', async () => {
+      const paramsBeforeAttempt = BurnParams.unpack(
+        tokenContract.packedBurnParams.get()
+      );
+      const fixedAmountBeforeAttempt = paramsBeforeAttempt.fixedAmount;
+      const minAmountBeforeAttempt = paramsBeforeAttempt.minAmount;
+      const maxAmountBeforeAttempt = paramsBeforeAttempt.maxAmount;
+
+      const newFixedAmountAttempt = UInt64.from(750);
+      const expectedErrorMessage =
+        'the required authorization was not provided or is invalid.';
+
+      await updateBurnFixedAmountTx(
+        user1,
+        newFixedAmountAttempt,
+        [user1.key],
+        expectedErrorMessage
+      );
+
+      const paramsAfterFailedUpdate = BurnParams.unpack(
+        tokenContract.packedBurnParams.get()
+      );
+      expect(paramsAfterFailedUpdate.fixedAmount).toEqual(
+        fixedAmountBeforeAttempt
+      );
+      expect(paramsAfterFailedUpdate.minAmount).toEqual(minAmountBeforeAttempt);
+      expect(paramsAfterFailedUpdate.maxAmount).toEqual(maxAmountBeforeAttempt);
+    });
+
+    it('should update burn min amount via field-specific function', async () => {
+      const paramsBeforeUpdate = BurnParams.unpack(
+        tokenContract.packedBurnParams.get()
+      );
+      const originalFixedAmount = paramsBeforeUpdate.fixedAmount;
+      const originalMaxAmount = paramsBeforeUpdate.maxAmount;
+
+      const newMinAmount = UInt64.from(100);
+      await updateBurnMinAmountTx(user1, newMinAmount, [
+        user1.key,
+        tokenAdmin.key,
+      ]);
+
+      const paramsAfterUpdate = BurnParams.unpack(
+        tokenContract.packedBurnParams.get()
+      );
+      expect(paramsAfterUpdate.minAmount).toEqual(newMinAmount);
+      expect(paramsAfterUpdate.fixedAmount).toEqual(originalFixedAmount);
+      expect(paramsAfterUpdate.maxAmount).toEqual(originalMaxAmount);
+    });
+
+    it('should reject burn min amount update via field-specific function when unauthorized by the admin', async () => {
+      const paramsBeforeAttempt = BurnParams.unpack(
+        tokenContract.packedBurnParams.get()
+      );
+      const originalFixedAmount = paramsBeforeAttempt.fixedAmount;
+      const originalMinAmount = paramsBeforeAttempt.minAmount;
+      const originalMaxAmount = paramsBeforeAttempt.maxAmount;
+
+      const newMinAmountAttempt = UInt64.from(150);
+      const expectedErrorMessage =
+        'the required authorization was not provided or is invalid.';
+
+      await updateBurnMinAmountTx(
+        user1,
+        newMinAmountAttempt,
+        [user1.key],
+        expectedErrorMessage
+      );
+
+      const paramsAfterFailedUpdate = BurnParams.unpack(
+        tokenContract.packedBurnParams.get()
+      );
+      expect(paramsAfterFailedUpdate.minAmount).toEqual(originalMinAmount);
+      expect(paramsAfterFailedUpdate.fixedAmount).toEqual(originalFixedAmount);
+      expect(paramsAfterFailedUpdate.maxAmount).toEqual(originalMaxAmount);
+    });
+
+    it('should reject burn min amount update via field-specific function when minAmount > maxAmount', async () => {
+      const paramsBeforeAttempt = BurnParams.unpack(
+        tokenContract.packedBurnParams.get()
+      );
+      const originalFixedAmount = paramsBeforeAttempt.fixedAmount;
+      const originalMinAmount = paramsBeforeAttempt.minAmount;
+      const originalMaxAmount = paramsBeforeAttempt.maxAmount;
+
+      const invalidNewMinAmount = originalMaxAmount.add(100);
+      const expectedErrorMessage = 'Invalid amount range!';
+
+      await updateBurnMinAmountTx(
+        user1,
+        invalidNewMinAmount,
+        [user1.key, tokenAdmin.key],
+        expectedErrorMessage
+      );
+
+      const paramsAfterFailedUpdate = BurnParams.unpack(
+        tokenContract.packedBurnParams.get()
+      );
+      expect(paramsAfterFailedUpdate.minAmount).toEqual(originalMinAmount);
+      expect(paramsAfterFailedUpdate.fixedAmount).toEqual(originalFixedAmount);
+      expect(paramsAfterFailedUpdate.maxAmount).toEqual(originalMaxAmount);
+    });
+
+    it('should update burn max amount via field-specific function', async () => {
+      const paramsBeforeUpdate = BurnParams.unpack(
+        tokenContract.packedBurnParams.get()
+      );
+      const originalFixedAmount = paramsBeforeUpdate.fixedAmount;
+      const originalMinAmount = paramsBeforeUpdate.minAmount;
+
+      const newMaxAmount = UInt64.from(850);
+      await updateBurnMaxAmountTx(user1, newMaxAmount, [
+        user1.key,
+        tokenAdmin.key,
+      ]);
+
+      const paramsAfterUpdate = BurnParams.unpack(
+        tokenContract.packedBurnParams.get()
+      );
+      expect(paramsAfterUpdate.maxAmount).toEqual(newMaxAmount);
+      expect(paramsAfterUpdate.fixedAmount).toEqual(originalFixedAmount);
+      expect(paramsAfterUpdate.minAmount).toEqual(originalMinAmount);
+    });
+
+    it('should reject burn max amount update via field-specific function when unauthorized by the admin', async () => {
+      const paramsBeforeAttempt = BurnParams.unpack(
+        tokenContract.packedBurnParams.get()
+      );
+      const originalFixedAmount = paramsBeforeAttempt.fixedAmount;
+      const originalMinAmount = paramsBeforeAttempt.minAmount;
+      const originalMaxAmount = paramsBeforeAttempt.maxAmount;
+
+      const newMaxAmountAttempt = UInt64.from(1300);
+      const expectedErrorMessage =
+        'the required authorization was not provided or is invalid.';
+
+      await updateBurnMaxAmountTx(
+        user1,
+        newMaxAmountAttempt,
+        [user1.key],
+        expectedErrorMessage
+      );
+
+      const paramsAfterFailedUpdate = BurnParams.unpack(
+        tokenContract.packedBurnParams.get()
+      );
+      expect(paramsAfterFailedUpdate.maxAmount).toEqual(originalMaxAmount);
+      expect(paramsAfterFailedUpdate.fixedAmount).toEqual(originalFixedAmount);
+      expect(paramsAfterFailedUpdate.minAmount).toEqual(originalMinAmount);
+    });
+
+    it('should reject burn max amount update via field-specific function when maxAmount < minAmount', async () => {
+      const paramsBeforeAttempt = BurnParams.unpack(
+        tokenContract.packedBurnParams.get()
+      );
+      const originalFixedAmount = paramsBeforeAttempt.fixedAmount;
+      const originalMinAmount = paramsBeforeAttempt.minAmount;
+      const originalMaxAmount = paramsBeforeAttempt.maxAmount;
+
+      const invalidNewMaxAmount = originalMinAmount.sub(10);
+      const expectedErrorMessage = 'Invalid amount range!';
+
+      await updateBurnMaxAmountTx(
+        user1,
+        invalidNewMaxAmount,
+        [user1.key, tokenAdmin.key],
+        expectedErrorMessage
+      );
+
+      const paramsAfterFailedUpdate = BurnParams.unpack(
+        tokenContract.packedBurnParams.get()
+      );
+      expect(paramsAfterFailedUpdate.maxAmount).toEqual(originalMaxAmount);
+      expect(paramsAfterFailedUpdate.fixedAmount).toEqual(originalFixedAmount);
+      expect(paramsAfterFailedUpdate.minAmount).toEqual(originalMinAmount);
     });
   });
 

--- a/src/test/burn.test.ts
+++ b/src/test/burn.test.ts
@@ -229,6 +229,174 @@ describe('New Token Standard Burn Tests', () => {
     }
   }
 
+  async function updateBurnFixedAmountConfigTx(
+    user: PublicKey,
+    value: Bool,
+    signers: PrivateKey[],
+    expectedErrorMessage?: string
+  ) {
+    try {
+      const tx = await Mina.transaction({ sender: user, fee }, async () => {
+        await tokenContract.updateBurnFixedAmountConfig(value);
+      });
+      await tx.prove();
+      await tx.sign(signers).send().wait();
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const burnConfigAfter = BurnConfig.unpack(packedConfigsAfter);
+      expect(burnConfigAfter.fixedAmount).toEqual(value);
+
+      if (expectedErrorMessage) {
+        throw new Error(
+          `Test should have failed with '${expectedErrorMessage}' but didnt!`
+        );
+      }
+    } catch (error: unknown) {
+      if (!expectedErrorMessage) throw error;
+      expect((error as Error).message).toContain(expectedErrorMessage);
+    }
+  }
+
+  async function updateBurnRangedAmountConfigTx(
+    user: PublicKey,
+    value: Bool,
+    signers: PrivateKey[],
+    expectedErrorMessage?: string
+  ) {
+    try {
+      const tx = await Mina.transaction({ sender: user, fee }, async () => {
+        await tokenContract.updateBurnRangedAmountConfig(value);
+      });
+      await tx.prove();
+      await tx.sign(signers).send().wait();
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const burnConfigAfter = BurnConfig.unpack(packedConfigsAfter);
+      expect(burnConfigAfter.rangedAmount).toEqual(value);
+
+      if (expectedErrorMessage) {
+        throw new Error(
+          `Test should have failed with '${expectedErrorMessage}' but didnt!`
+        );
+      }
+    } catch (error: unknown) {
+      if (!expectedErrorMessage) throw error;
+      expect((error as Error).message).toContain(expectedErrorMessage);
+    }
+  }
+
+  async function updateBurnUnauthorizedConfigTx(
+    user: PublicKey,
+    value: Bool,
+    signers: PrivateKey[],
+    expectedErrorMessage?: string
+  ) {
+    try {
+      const tx = await Mina.transaction({ sender: user, fee }, async () => {
+        await tokenContract.updateBurnUnauthorizedConfig(value);
+      });
+      await tx.prove();
+      await tx.sign(signers).send().wait();
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const burnConfigAfter = BurnConfig.unpack(packedConfigsAfter);
+      expect(burnConfigAfter.unauthorized).toEqual(value);
+
+      if (expectedErrorMessage) {
+        throw new Error(
+          `Test should have failed with '${expectedErrorMessage}' but didnt!`
+        );
+      }
+    } catch (error: unknown) {
+      if (!expectedErrorMessage) throw error;
+      expect((error as Error).message).toContain(expectedErrorMessage);
+    }
+  }
+
+  async function updateBurnFixedAmountTx(
+    user: PublicKey,
+    value: UInt64,
+    signers: PrivateKey[],
+    expectedErrorMessage?: string
+  ) {
+    try {
+      const tx = await Mina.transaction({ sender: user, fee }, async () => {
+        await tokenContract.updateBurnFixedAmount(value);
+      });
+      await tx.prove();
+      await tx.sign(signers).send().wait();
+
+      const packedParams = tokenContract.packedBurnParams.get();
+      const params = BurnParams.unpack(packedParams);
+      expect(params.fixedAmount).toEqual(value);
+
+      if (expectedErrorMessage) {
+        throw new Error(
+          `Test should have failed with '${expectedErrorMessage}' but didnt!`
+        );
+      }
+    } catch (error: unknown) {
+      if (!expectedErrorMessage) throw error;
+      expect((error as Error).message).toContain(expectedErrorMessage);
+    }
+  }
+
+  async function updateBurnMinAmountTx(
+    user: PublicKey,
+    value: UInt64,
+    signers: PrivateKey[],
+    expectedErrorMessage?: string
+  ) {
+    try {
+      const tx = await Mina.transaction({ sender: user, fee }, async () => {
+        await tokenContract.updateBurnMinAmount(value);
+      });
+      await tx.prove();
+      await tx.sign(signers).send().wait();
+
+      const packedParams = tokenContract.packedBurnParams.get();
+      const params = BurnParams.unpack(packedParams);
+      expect(params.minAmount).toEqual(value);
+
+      if (expectedErrorMessage) {
+        throw new Error(
+          `Test should have failed with '${expectedErrorMessage}' but didnt!`
+        );
+      }
+    } catch (error: unknown) {
+      if (!expectedErrorMessage) throw error;
+      expect((error as Error).message).toContain(expectedErrorMessage);
+    }
+  }
+
+  async function updateBurnMaxAmountTx(
+    user: PublicKey,
+    value: UInt64,
+    signers: PrivateKey[],
+    expectedErrorMessage?: string
+  ) {
+    try {
+      const tx = await Mina.transaction({ sender: user, fee }, async () => {
+        await tokenContract.updateBurnMaxAmount(value);
+      });
+      await tx.prove();
+      await tx.sign(signers).send().wait();
+
+      const packedParams = tokenContract.packedBurnParams.get();
+      const params = BurnParams.unpack(packedParams);
+      expect(params.maxAmount).toEqual(value);
+
+      if (expectedErrorMessage) {
+        throw new Error(
+          `Test should have failed with '${expectedErrorMessage}' but didnt!`
+        );
+      }
+    } catch (error: unknown) {
+      if (!expectedErrorMessage) throw error;
+      expect((error as Error).message).toContain(expectedErrorMessage);
+    }
+  }
+
   describe('Deploy & initialize', () => {
     it('should deploy tokenA contract', async () => {
       const tx = await Mina.transaction({ sender: deployer, fee }, async () => {

--- a/src/test/burn.test.ts
+++ b/src/test/burn.test.ts
@@ -539,12 +539,149 @@ describe('New Token Standard Burn Tests', () => {
 
     it('should update packed burnConfig', async () => {
       const burnConfig = new BurnConfig({
-        unauthorized: Bool(true),
-        fixedAmount: Bool(true),
-        rangedAmount: Bool(false),
+        unauthorized: Bool(false),
+        fixedAmount: Bool(false),
+        rangedAmount: Bool(true),
       });
 
       await updateBurnConfigTx(user2, burnConfig, [user2.key, tokenAdmin.key]);
+    });
+
+    it('should update burn fixedAmount config via field-specific function', async () => {
+      const packedConfigsBefore = tokenContract.packedAmountConfigs.get();
+      const burnConfigBefore = BurnConfig.unpack(packedConfigsBefore);
+      const originalUnauthorized = burnConfigBefore.unauthorized;
+      const originalRangedAmount = burnConfigBefore.rangedAmount;
+
+      const newFixedAmountValue = Bool(true);
+      await updateBurnFixedAmountConfigTx(user2, newFixedAmountValue, [
+        user2.key,
+        tokenAdmin.key,
+      ]);
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const burnConfigAfter = BurnConfig.unpack(packedConfigsAfter);
+
+      expect(burnConfigAfter.fixedAmount).toEqual(newFixedAmountValue);
+      expect(burnConfigAfter.unauthorized).toEqual(originalUnauthorized);
+      expect(burnConfigAfter.rangedAmount).toEqual(newFixedAmountValue.not());
+    });
+
+    it('should reject burn fixed amount config update via field-specific function when unauthorized by the admin', async () => {
+      const packedConfigsBefore = tokenContract.packedAmountConfigs.get();
+      const burnConfigBefore = BurnConfig.unpack(packedConfigsBefore);
+      const originalFixedAmount = burnConfigBefore.fixedAmount;
+      const originalRangedAmount = burnConfigBefore.rangedAmount;
+      const originalUnauthorized = burnConfigBefore.unauthorized;
+
+      const attemptFixedAmountValue = Bool(true);
+      const expectedErrorMessage =
+        'the required authorization was not provided or is invalid.';
+
+      await updateBurnFixedAmountConfigTx(
+        user2,
+        attemptFixedAmountValue,
+        [user2.key],
+        expectedErrorMessage
+      );
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const burnConfigAfter = BurnConfig.unpack(packedConfigsAfter);
+
+      expect(burnConfigAfter.fixedAmount).toEqual(originalFixedAmount);
+      expect(burnConfigAfter.rangedAmount).toEqual(originalRangedAmount);
+      expect(burnConfigAfter.unauthorized).toEqual(originalUnauthorized);
+    });
+
+    it('should update burn ranged amount config via field-specific function', async () => {
+      const packedConfigsBefore = tokenContract.packedAmountConfigs.get();
+      const burnConfigBefore = BurnConfig.unpack(packedConfigsBefore);
+      const originalFixedAmount = burnConfigBefore.fixedAmount;
+      const originalUnauthorized = burnConfigBefore.unauthorized;
+      const newRangedAmountValue = Bool(false);
+      await updateBurnRangedAmountConfigTx(user2, newRangedAmountValue, [
+        user2.key,
+        tokenAdmin.key,
+      ]);
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const burnConfigAfter = BurnConfig.unpack(packedConfigsAfter);
+
+      expect(burnConfigAfter.rangedAmount).toEqual(newRangedAmountValue);
+      expect(burnConfigAfter.fixedAmount).toEqual(newRangedAmountValue.not());
+      expect(burnConfigAfter.unauthorized).toEqual(originalUnauthorized);
+    });
+
+    it('should reject rangedAmount config update via field-specific function when unauthorized by the admin', async () => {
+      const packedConfigsBefore = tokenContract.packedAmountConfigs.get();
+      const burnConfigBefore = BurnConfig.unpack(packedConfigsBefore);
+      const originalFixedAmount = burnConfigBefore.fixedAmount;
+      const originalRangedAmount = burnConfigBefore.rangedAmount;
+      const originalUnauthorized = burnConfigBefore.unauthorized;
+
+      const attemptRangedAmountValue = Bool(true);
+      const expectedErrorMessage =
+        'the required authorization was not provided or is invalid.';
+
+      await updateBurnRangedAmountConfigTx(
+        user2,
+        attemptRangedAmountValue,
+        [user2.key],
+        expectedErrorMessage
+      );
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const burnConfigAfter = BurnConfig.unpack(packedConfigsAfter);
+
+      expect(burnConfigAfter.rangedAmount).toEqual(originalRangedAmount);
+      expect(burnConfigAfter.fixedAmount).toEqual(originalFixedAmount);
+      expect(burnConfigAfter.unauthorized).toEqual(originalUnauthorized);
+    });
+
+    it('should update burn unauthorized config via field-specific function', async () => {
+      const packedConfigsBefore = tokenContract.packedAmountConfigs.get();
+      const burnConfigBefore = BurnConfig.unpack(packedConfigsBefore);
+      const originalFixedAmount = burnConfigBefore.fixedAmount;
+      const originalRangedAmount = burnConfigBefore.rangedAmount;
+
+      const newUnauthorizedValue = Bool(true);
+      await updateBurnUnauthorizedConfigTx(user2, newUnauthorizedValue, [
+        user2.key,
+        tokenAdmin.key,
+      ]);
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const burnConfigAfter = BurnConfig.unpack(packedConfigsAfter);
+
+      expect(burnConfigAfter.unauthorized).toEqual(newUnauthorizedValue);
+      expect(burnConfigAfter.fixedAmount).toEqual(originalFixedAmount);
+      expect(burnConfigAfter.rangedAmount).toEqual(originalRangedAmount);
+    });
+
+    it('should reject unauthorized config update via field-specific function when unauthorized by the admin', async () => {
+      const packedConfigsBefore = tokenContract.packedAmountConfigs.get();
+      const burnConfigBefore = BurnConfig.unpack(packedConfigsBefore);
+      const originalFixedAmount = burnConfigBefore.fixedAmount;
+      const originalRangedAmount = burnConfigBefore.rangedAmount;
+      const originalUnauthorized = burnConfigBefore.unauthorized;
+
+      const attemptUnauthorizedValue = Bool(false);
+      const expectedErrorMessage =
+        'the required authorization was not provided or is invalid.';
+
+      await updateBurnUnauthorizedConfigTx(
+        user2,
+        attemptUnauthorizedValue,
+        [user2.key],
+        expectedErrorMessage
+      );
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const burnConfigAfter = BurnConfig.unpack(packedConfigsAfter);
+
+      expect(burnConfigAfter.unauthorized).toEqual(originalUnauthorized);
+      expect(burnConfigAfter.fixedAmount).toEqual(originalFixedAmount);
+      expect(burnConfigAfter.rangedAmount).toEqual(originalRangedAmount);
     });
   });
 

--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -1,0 +1,36 @@
+/**
+ * Constants for mint/burn config property names
+ * These can be used across tests to avoid string literals and improve type safety
+ */
+export const CONFIG_PROPERTIES = {
+  FIXED_AMOUNT: 'fixedAmount',
+  RANGED_AMOUNT: 'rangedAmount',
+  UNAUTHORIZED: 'unauthorized',
+} as const;
+
+/**
+ * Constants for mint/burn params property names
+ */
+export const PARAMS_PROPERTIES = {
+  FIXED_AMOUNT: 'fixedAmount',
+  MIN_AMOUNT: 'minAmount',
+  MAX_AMOUNT: 'maxAmount',
+} as const;
+
+/**
+ * Type definitions for better type safety
+ */
+export type ConfigProperty = typeof CONFIG_PROPERTIES[keyof typeof CONFIG_PROPERTIES];
+export type ParamsProperty = typeof PARAMS_PROPERTIES[keyof typeof PARAMS_PROPERTIES];
+
+/**
+ * All available config properties as a typed array
+ * Useful for iteration or validation
+ */
+export const ALL_CONFIG_PROPERTIES = Object.values(CONFIG_PROPERTIES) as ConfigProperty[];
+
+/**
+ * All available params properties as a typed array
+ * Useful for iteration or validation
+ */
+export const ALL_PARAMS_PROPERTIES = Object.values(PARAMS_PROPERTIES) as ParamsProperty[]; 

--- a/src/test/mint.test.ts
+++ b/src/test/mint.test.ts
@@ -31,7 +31,7 @@ import {
 } from '../side-loaded/program.eg.js';
 
 //! Tests can take up to 15 minutes with `proofsEnabled: true`, and around 4 minutes when false.
-const proofsEnabled = true;
+const proofsEnabled = false;
 
 describe('New Token Standard Mint Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;

--- a/src/test/mint.test.ts
+++ b/src/test/mint.test.ts
@@ -620,12 +620,149 @@ describe('New Token Standard Mint Tests', () => {
 
     it('should update packed mintConfig', async () => {
       const mintConfig = new MintConfig({
-        unauthorized: Bool(true),
-        fixedAmount: Bool(true),
-        rangedAmount: Bool(false),
+        unauthorized: Bool(false),
+        fixedAmount: Bool(false),
+        rangedAmount: Bool(true),
       });
 
       await updateMintConfigTx(user2, mintConfig, [user2.key, tokenAdmin.key]);
+    });
+
+    it('should update fixedAmount config via field-specific function', async () => {
+      const packedConfigsBefore = tokenContract.packedAmountConfigs.get();
+      const mintConfigBefore = MintConfig.unpack(packedConfigsBefore);
+      const originalUnauthorized = mintConfigBefore.unauthorized;
+      const originalRangedAmount = mintConfigBefore.rangedAmount;
+
+      const newFixedAmountValue = Bool(true);
+      await updateMintFixedAmountConfigTx(user2, newFixedAmountValue, [
+        user2.key,
+        tokenAdmin.key,
+      ]);
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const mintConfigAfter = MintConfig.unpack(packedConfigsAfter);
+
+      expect(mintConfigAfter.fixedAmount).toEqual(newFixedAmountValue);
+      expect(mintConfigAfter.unauthorized).toEqual(originalUnauthorized);
+      expect(mintConfigAfter.rangedAmount).toEqual(newFixedAmountValue.not());
+    });
+
+    it('should reject mint fixed amount config update via field-specific function when unauthorized by the admin', async () => {
+      const packedConfigsBefore = tokenContract.packedAmountConfigs.get();
+      const mintConfigBefore = MintConfig.unpack(packedConfigsBefore);
+      const originalFixedAmount = mintConfigBefore.fixedAmount;
+      const originalRangedAmount = mintConfigBefore.rangedAmount;
+      const originalUnauthorized = mintConfigBefore.unauthorized;
+
+      const attemptFixedAmountValue = Bool(false);
+      const expectedErrorMessage =
+        'the required authorization was not provided or is invalid.';
+
+      await updateMintFixedAmountConfigTx(
+        user2,
+        attemptFixedAmountValue,
+        [user2.key],
+        expectedErrorMessage
+      );
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const mintConfigAfter = MintConfig.unpack(packedConfigsAfter);
+
+      expect(mintConfigAfter.fixedAmount).toEqual(originalFixedAmount);
+      expect(mintConfigAfter.rangedAmount).toEqual(originalRangedAmount);
+      expect(mintConfigAfter.unauthorized).toEqual(originalUnauthorized);
+    });
+
+    it('should update mint ranged amount config via field-specific function', async () => {
+      const packedConfigsBefore = tokenContract.packedAmountConfigs.get();
+      const mintConfigBefore = MintConfig.unpack(packedConfigsBefore);
+      const originalFixedAmount = mintConfigBefore.fixedAmount;
+      const originalUnauthorized = mintConfigBefore.unauthorized;
+      const newRangedAmountValue = Bool(false);
+      await updateMintRangedAmountConfigTx(user2, newRangedAmountValue, [
+        user2.key,
+        tokenAdmin.key,
+      ]);
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const mintConfigAfter = MintConfig.unpack(packedConfigsAfter);
+
+      expect(mintConfigAfter.rangedAmount).toEqual(newRangedAmountValue);
+      expect(mintConfigAfter.fixedAmount).toEqual(newRangedAmountValue.not());
+      expect(mintConfigAfter.unauthorized).toEqual(originalUnauthorized);
+    });
+
+    it('should reject rangedAmount config update via field-specific function when unauthorized by the admin', async () => {
+      const packedConfigsBefore = tokenContract.packedAmountConfigs.get();
+      const mintConfigBefore = MintConfig.unpack(packedConfigsBefore);
+      const originalFixedAmount = mintConfigBefore.fixedAmount;
+      const originalRangedAmount = mintConfigBefore.rangedAmount;
+      const originalUnauthorized = mintConfigBefore.unauthorized;
+
+      const attemptRangedAmountValue = Bool(true);
+      const expectedErrorMessage =
+        'the required authorization was not provided or is invalid.';
+
+      await updateMintRangedAmountConfigTx(
+        user2,
+        attemptRangedAmountValue,
+        [user2.key],
+        expectedErrorMessage
+      );
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const mintConfigAfter = MintConfig.unpack(packedConfigsAfter);
+
+      expect(mintConfigAfter.rangedAmount).toEqual(originalRangedAmount);
+      expect(mintConfigAfter.fixedAmount).toEqual(originalFixedAmount);
+      expect(mintConfigAfter.unauthorized).toEqual(originalUnauthorized);
+    });
+
+    it('should update mint unauthorized config via field-specific function', async () => {
+      const packedConfigsBefore = tokenContract.packedAmountConfigs.get();
+      const mintConfigBefore = MintConfig.unpack(packedConfigsBefore);
+      const originalFixedAmount = mintConfigBefore.fixedAmount;
+      const originalRangedAmount = mintConfigBefore.rangedAmount;
+
+      const newUnauthorizedValue = Bool(true);
+      await updateMintUnauthorizedConfigTx(user2, newUnauthorizedValue, [
+        user2.key,
+        tokenAdmin.key,
+      ]);
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const mintConfigAfter = MintConfig.unpack(packedConfigsAfter);
+
+      expect(mintConfigAfter.unauthorized).toEqual(newUnauthorizedValue);
+      expect(mintConfigAfter.fixedAmount).toEqual(originalFixedAmount);
+      expect(mintConfigAfter.rangedAmount).toEqual(originalRangedAmount);
+    });
+
+    it('should reject unauthorized config update via field-specific function when unauthorized by the admin', async () => {
+      const packedConfigsBefore = tokenContract.packedAmountConfigs.get();
+      const mintConfigBefore = MintConfig.unpack(packedConfigsBefore);
+      const originalFixedAmount = mintConfigBefore.fixedAmount;
+      const originalRangedAmount = mintConfigBefore.rangedAmount;
+      const originalUnauthorized = mintConfigBefore.unauthorized;
+
+      const attemptUnauthorizedValue = Bool(true);
+      const expectedErrorMessage =
+        'the required authorization was not provided or is invalid.';
+
+      await updateMintUnauthorizedConfigTx(
+        user2,
+        attemptUnauthorizedValue,
+        [user2.key],
+        expectedErrorMessage
+      );
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const mintConfigAfter = MintConfig.unpack(packedConfigsAfter);
+
+      expect(mintConfigAfter.unauthorized).toEqual(originalUnauthorized);
+      expect(mintConfigAfter.fixedAmount).toEqual(originalFixedAmount);
+      expect(mintConfigAfter.rangedAmount).toEqual(originalRangedAmount);
     });
   });
 

--- a/src/test/mint.test.ts
+++ b/src/test/mint.test.ts
@@ -264,6 +264,174 @@ describe('New Token Standard Mint Tests', () => {
     }
   }
 
+  async function updateMintFixedAmountTx(
+    user: PublicKey,
+    value: UInt64,
+    signers: PrivateKey[],
+    expectedErrorMessage?: string
+  ) {
+    try {
+      const tx = await Mina.transaction({ sender: user, fee }, async () => {
+        await tokenContract.updateMintFixedAmount(value);
+      });
+      await tx.prove();
+      await tx.sign(signers).send().wait();
+
+      const packedParams = tokenContract.packedMintParams.get();
+      const params = MintParams.unpack(packedParams);
+      expect(params.fixedAmount).toEqual(value);
+
+      if (expectedErrorMessage) {
+        throw new Error(
+          `Test should have failed with '${expectedErrorMessage}' but didnt!`
+        );
+      }
+    } catch (error: unknown) {
+      if (!expectedErrorMessage) throw error;
+      expect((error as Error).message).toContain(expectedErrorMessage);
+    }
+  }
+
+  async function updateMintMinAmountTx(
+    user: PublicKey,
+    value: UInt64,
+    signers: PrivateKey[],
+    expectedErrorMessage?: string
+  ) {
+    try {
+      const tx = await Mina.transaction({ sender: user, fee }, async () => {
+        await tokenContract.updateMintMinAmount(value);
+      });
+      await tx.prove();
+      await tx.sign(signers).send().wait();
+
+      const packedParams = tokenContract.packedMintParams.get();
+      const params = MintParams.unpack(packedParams);
+      expect(params.minAmount).toEqual(value);
+
+      if (expectedErrorMessage) {
+        throw new Error(
+          `Test should have failed with '${expectedErrorMessage}' but didnt!`
+        );
+      }
+    } catch (error: unknown) {
+      if (!expectedErrorMessage) throw error;
+      expect((error as Error).message).toContain(expectedErrorMessage);
+    }
+  }
+
+  async function updateMintMaxAmountTx(
+    user: PublicKey,
+    value: UInt64,
+    signers: PrivateKey[],
+    expectedErrorMessage?: string
+  ) {
+    try {
+      const tx = await Mina.transaction({ sender: user, fee }, async () => {
+        await tokenContract.updateMintMaxAmount(value);
+      });
+      await tx.prove();
+      await tx.sign(signers).send().wait();
+
+      const packedParams = tokenContract.packedMintParams.get();
+      const params = MintParams.unpack(packedParams);
+      expect(params.maxAmount).toEqual(value);
+
+      if (expectedErrorMessage) {
+        throw new Error(
+          `Test should have failed with '${expectedErrorMessage}' but didnt!`
+        );
+      }
+    } catch (error: unknown) {
+      if (!expectedErrorMessage) throw error;
+      expect((error as Error).message).toContain(expectedErrorMessage);
+    }
+  }
+
+  async function updateMintFixedAmountConfigTx(
+    user: PublicKey,
+    value: Bool,
+    signers: PrivateKey[],
+    expectedErrorMessage?: string
+  ) {
+    try {
+      const tx = await Mina.transaction({ sender: user, fee }, async () => {
+        await tokenContract.updateMintFixedAmountConfig(value);
+      });
+      await tx.prove();
+      await tx.sign(signers).send().wait();
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const mintConfigAfter = MintConfig.unpack(packedConfigsAfter);
+      expect(mintConfigAfter.fixedAmount).toEqual(value);
+
+      if (expectedErrorMessage) {
+        throw new Error(
+          `Test should have failed with '${expectedErrorMessage}' but didnt!`
+        );
+      }
+    } catch (error: unknown) {
+      if (!expectedErrorMessage) throw error;
+      expect((error as Error).message).toContain(expectedErrorMessage);
+    }
+  }
+
+  async function updateMintRangedAmountConfigTx(
+    user: PublicKey,
+    value: Bool,
+    signers: PrivateKey[],
+    expectedErrorMessage?: string
+  ) {
+    try {
+      const tx = await Mina.transaction({ sender: user, fee }, async () => {
+        await tokenContract.updateMintRangedAmountConfig(value);
+      });
+      await tx.prove();
+      await tx.sign(signers).send().wait();
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const mintConfigAfter = MintConfig.unpack(packedConfigsAfter);
+      expect(mintConfigAfter.rangedAmount).toEqual(value);
+
+      if (expectedErrorMessage) {
+        throw new Error(
+          `Test should have failed with '${expectedErrorMessage}' but didnt!`
+        );
+      }
+    } catch (error: unknown) {
+      if (!expectedErrorMessage) throw error;
+      expect((error as Error).message).toContain(expectedErrorMessage);
+    }
+  }
+
+  async function updateMintUnauthorizedConfigTx(
+    user: PublicKey,
+    value: Bool,
+    signers: PrivateKey[],
+    expectedErrorMessage?: string
+  ) {
+    try {
+      const tx = await Mina.transaction({ sender: user, fee }, async () => {
+        await tokenContract.updateMintUnauthorizedConfig(value);
+      });
+      await tx.prove();
+      await tx.sign(signers).send().wait();
+
+      const packedConfigsAfter = tokenContract.packedAmountConfigs.get();
+      const mintConfigAfter = MintConfig.unpack(packedConfigsAfter);
+      expect(mintConfigAfter.unauthorized).toEqual(value);
+
+      if (expectedErrorMessage) {
+        throw new Error(
+          `Test should have failed with '${expectedErrorMessage}' but didnt!`
+        );
+      }
+    } catch (error: unknown) {
+      if (!expectedErrorMessage) throw error;
+      expect((error as Error).message).toContain(expectedErrorMessage);
+    }
+  }
+
   describe('Deploy & initialize', () => {
     it('should deploy tokenA contract', async () => {
       const tx = await Mina.transaction({ sender: deployer, fee }, async () => {

--- a/src/test/mint.test.ts
+++ b/src/test/mint.test.ts
@@ -1114,10 +1114,13 @@ describe('New Token Standard Mint Tests', () => {
     });
 
     it('should update the side-loaded vKey hash for mints', async () => {
-      await updateSLVkeyHashTx(user1, programVkey, vKeyMap, OperationKeys.Mint, [
-        user1.key,
-        tokenAdmin.key,
-      ]);
+      await updateSLVkeyHashTx(
+        user1,
+        programVkey,
+        vKeyMap,
+        OperationKeys.Mint,
+        [user1.key, tokenAdmin.key]
+      );
       vKeyMap.set(OperationKeys.Mint, programVkey.hash);
       expect(tokenContract.vKeyMapRoot.get()).toEqual(vKeyMap.root);
     });

--- a/src/test/mint.test.ts
+++ b/src/test/mint.test.ts
@@ -785,7 +785,7 @@ describe('New Token Standard Mint Tests', () => {
 
     it('should reject mintParams update when unauthorized by the admin', async () => {
       mintParams = new MintParams({
-        fixedAmount: UInt64.from(600),
+        fixedAmount: UInt64.from(300),
         minAmount: UInt64.from(100),
         maxAmount: UInt64.from(900),
       });
@@ -802,6 +802,199 @@ describe('New Token Standard Mint Tests', () => {
 
     it('should update packed mintParams', async () => {
       await updateMintParamsTx(user1, mintParams, [user1.key, tokenAdmin.key]);
+    });
+
+    it('should update mint fixed amount via field-specific function', async () => {
+      const newFixedAmount = UInt64.from(600);
+      await updateMintFixedAmountTx(user1, newFixedAmount, [
+        user1.key,
+        tokenAdmin.key,
+      ]);
+
+      const paramsAfterUpdate = MintParams.unpack(
+        tokenContract.packedMintParams.get()
+      );
+      expect(paramsAfterUpdate.fixedAmount).toEqual(newFixedAmount);
+      expect(paramsAfterUpdate.minAmount).toEqual(mintParams.minAmount);
+      expect(paramsAfterUpdate.maxAmount).toEqual(mintParams.maxAmount);
+    });
+
+    it('should reject mint fixed amount update via field-specific function when unauthorized by the admin', async () => {
+      1;
+      const paramsBeforeAttempt = MintParams.unpack(
+        tokenContract.packedMintParams.get()
+      );
+      const fixedAmountBeforeAttempt = paramsBeforeAttempt.fixedAmount;
+      const minAmountBeforeAttempt = paramsBeforeAttempt.minAmount;
+      const maxAmountBeforeAttempt = paramsBeforeAttempt.maxAmount;
+
+      const newFixedAmountAttempt = UInt64.from(750);
+      const expectedErrorMessage =
+        'the required authorization was not provided or is invalid.';
+
+      await updateMintFixedAmountTx(
+        user1,
+        newFixedAmountAttempt,
+        [user1.key],
+        expectedErrorMessage
+      );
+
+      const paramsAfterFailedUpdate = MintParams.unpack(
+        tokenContract.packedMintParams.get()
+      );
+      expect(paramsAfterFailedUpdate.fixedAmount).toEqual(
+        fixedAmountBeforeAttempt
+      );
+      expect(paramsAfterFailedUpdate.minAmount).toEqual(minAmountBeforeAttempt);
+      expect(paramsAfterFailedUpdate.maxAmount).toEqual(maxAmountBeforeAttempt);
+    });
+
+    it('should update mint min amount via field-specific function', async () => {
+      const paramsBeforeUpdate = MintParams.unpack(
+        tokenContract.packedMintParams.get()
+      );
+      const originalFixedAmount = paramsBeforeUpdate.fixedAmount;
+      const originalMaxAmount = paramsBeforeUpdate.maxAmount;
+
+      const newMinAmount = UInt64.from(50);
+      await updateMintMinAmountTx(user1, newMinAmount, [
+        user1.key,
+        tokenAdmin.key,
+      ]);
+
+      const paramsAfterUpdate = MintParams.unpack(
+        tokenContract.packedMintParams.get()
+      );
+      expect(paramsAfterUpdate.minAmount).toEqual(newMinAmount);
+      expect(paramsAfterUpdate.fixedAmount).toEqual(originalFixedAmount); // Should not change
+      expect(paramsAfterUpdate.maxAmount).toEqual(originalMaxAmount); // Should not change
+    });
+
+    it('should reject mint min amount update via field-specific function when unauthorized by the admin', async () => {
+      const paramsBeforeAttempt = MintParams.unpack(
+        tokenContract.packedMintParams.get()
+      );
+      const originalFixedAmount = paramsBeforeAttempt.fixedAmount;
+      const originalMinAmount = paramsBeforeAttempt.minAmount;
+      const originalMaxAmount = paramsBeforeAttempt.maxAmount;
+
+      const newMinAmountAttempt = UInt64.from(150);
+      const expectedErrorMessage =
+        'the required authorization was not provided or is invalid.';
+
+      await updateMintMinAmountTx(
+        user1,
+        newMinAmountAttempt,
+        [user1.key], // No admin signature
+        expectedErrorMessage
+      );
+
+      const paramsAfterFailedUpdate = MintParams.unpack(
+        tokenContract.packedMintParams.get()
+      );
+      expect(paramsAfterFailedUpdate.minAmount).toEqual(originalMinAmount);
+      expect(paramsAfterFailedUpdate.fixedAmount).toEqual(originalFixedAmount);
+      expect(paramsAfterFailedUpdate.maxAmount).toEqual(originalMaxAmount);
+    });
+
+    it('should reject mint min amount update via field-specific function when minAmount > maxAmount', async () => {
+      const paramsBeforeAttempt = MintParams.unpack(
+        tokenContract.packedMintParams.get()
+      );
+      const originalFixedAmount = paramsBeforeAttempt.fixedAmount;
+      const originalMinAmount = paramsBeforeAttempt.minAmount;
+      const originalMaxAmount = paramsBeforeAttempt.maxAmount;
+
+      const invalidNewMinAmount = originalMaxAmount.add(100);
+      const expectedErrorMessage = 'Invalid amount range!';
+
+      await updateMintMinAmountTx(
+        user1,
+        invalidNewMinAmount,
+        [user1.key, tokenAdmin.key],
+        expectedErrorMessage
+      );
+
+      const paramsAfterFailedUpdate = MintParams.unpack(
+        tokenContract.packedMintParams.get()
+      );
+      expect(paramsAfterFailedUpdate.minAmount).toEqual(originalMinAmount);
+      expect(paramsAfterFailedUpdate.fixedAmount).toEqual(originalFixedAmount);
+      expect(paramsAfterFailedUpdate.maxAmount).toEqual(originalMaxAmount);
+    });
+
+    it('should update mint max amount via field-specific function', async () => {
+      const paramsBeforeUpdate = MintParams.unpack(
+        tokenContract.packedMintParams.get()
+      );
+      const originalFixedAmount = paramsBeforeUpdate.fixedAmount;
+      const originalMinAmount = paramsBeforeUpdate.minAmount;
+
+      const newMaxAmount = UInt64.from(1200);
+      await updateMintMaxAmountTx(user1, newMaxAmount, [
+        user1.key,
+        tokenAdmin.key,
+      ]);
+
+      const paramsAfterUpdate = MintParams.unpack(
+        tokenContract.packedMintParams.get()
+      );
+      expect(paramsAfterUpdate.maxAmount).toEqual(newMaxAmount);
+      expect(paramsAfterUpdate.fixedAmount).toEqual(originalFixedAmount);
+      expect(paramsAfterUpdate.minAmount).toEqual(originalMinAmount);
+    });
+
+    it('should reject mint max amount update via field-specific function when unauthorized by the admin', async () => {
+      const paramsBeforeAttempt = MintParams.unpack(
+        tokenContract.packedMintParams.get()
+      );
+      const originalFixedAmount = paramsBeforeAttempt.fixedAmount;
+      const originalMinAmount = paramsBeforeAttempt.minAmount;
+      const originalMaxAmount = paramsBeforeAttempt.maxAmount;
+
+      const newMaxAmountAttempt = UInt64.from(1300);
+      const expectedErrorMessage =
+        'the required authorization was not provided or is invalid.';
+
+      await updateMintMaxAmountTx(
+        user1,
+        newMaxAmountAttempt,
+        [user1.key],
+        expectedErrorMessage
+      );
+
+      const paramsAfterFailedUpdate = MintParams.unpack(
+        tokenContract.packedMintParams.get()
+      );
+      expect(paramsAfterFailedUpdate.maxAmount).toEqual(originalMaxAmount);
+      expect(paramsAfterFailedUpdate.fixedAmount).toEqual(originalFixedAmount);
+      expect(paramsAfterFailedUpdate.minAmount).toEqual(originalMinAmount);
+    });
+
+    it('should reject mint max amount update via field-specific function when maxAmount < minAmount', async () => {
+      const paramsBeforeAttempt = MintParams.unpack(
+        tokenContract.packedMintParams.get()
+      );
+      const originalFixedAmount = paramsBeforeAttempt.fixedAmount;
+      const originalMinAmount = paramsBeforeAttempt.minAmount;
+      const originalMaxAmount = paramsBeforeAttempt.maxAmount;
+
+      const invalidNewMaxAmount = originalMinAmount.sub(10);
+      const expectedErrorMessage = 'Invalid amount range!';
+
+      await updateMintMaxAmountTx(
+        user1,
+        invalidNewMaxAmount,
+        [user1.key, tokenAdmin.key],
+        expectedErrorMessage
+      );
+
+      const paramsAfterFailedUpdate = MintParams.unpack(
+        tokenContract.packedMintParams.get()
+      );
+      expect(paramsAfterFailedUpdate.maxAmount).toEqual(originalMaxAmount);
+      expect(paramsAfterFailedUpdate.fixedAmount).toEqual(originalFixedAmount);
+      expect(paramsAfterFailedUpdate.minAmount).toEqual(originalMinAmount);
     });
   });
 

--- a/src/test/transfer.test.ts
+++ b/src/test/transfer.test.ts
@@ -30,7 +30,7 @@ import {
   program2,
 } from '../side-loaded/program.eg.js';
 
-const proofsEnabled = true;
+const proofsEnabled = false;
 
 describe('New Token Standard Transfer Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;


### PR DESCRIPTION
## Description
This PR implements field-specific update functions for `MintParams`, `BurnParams`, `MintConfig`, and `BurnConfig`, eliminating the need for developers to manually manage full parameter objects when updating individual fields.

## Changes
**MintParams**:
- `updateMintFixedAmount(value: UInt64)` - Update fixed mint amount
- `updateMintMinAmount(value: UInt64)` - Update minimum mint amount with validation
- `updateMintMaxAmount(value: UInt64)` - Update maximum mint amount with validation

**BurnParams**:
- `updateBurnFixedAmount(value: UInt64)` - Update fixed burn amount
- `updateBurnMinAmount(value: UInt64)` - Update minimum burn amount with validation
- `updateBurnMaxAmount(value: UInt64)` - Update maximum burn amount with validation

**MintConfig**:
- `updateMintFixedAmountConfig(value: Bool)` - Toggle fixed amount mode
- `updateMintRangedAmountConfig(value: Bool)` - Toggle ranged amount mode
- `updateMintUnauthorizedConfig(value: Bool)` - Toggle authorization requirement

**BurnConfig**:
- `updateBurnFixedAmountConfig(value: Bool)` - Toggle fixed amount mode
- `updateBurnRangedAmountConfig(value: Bool)` - Toggle ranged amount mode
- `updateBurnUnauthorizedConfig(value: Bool)` - Toggle authorization requirement
