### PR TITLE
Refactor with constants

### DIFF
--- a/src/FungibleTokenStandard.ts
+++ b/src/FungibleTokenStandard.ts
@@ -36,6 +36,7 @@ import {
   ParameterTypes,
   FlagTypes,
   MERKLE_HEIGHT,
+  MINA_TOKEN_ID,
 } from './configs.js';
 import { SideloadedProof } from './side-loaded/program.eg.js';
 
@@ -128,8 +129,6 @@ const FungibleTokenErrors = {
   useCustomTransferMethod:
     'Method overridden: Use transferCustom() for side-loaded proof support instead of transfer()',
 };
-
-const MINA_TOKEN_ID = Field(1); // The native MINA token ID is always 1
 
 class FungibleToken extends TokenContract {
   @state(UInt8) decimals = State<UInt8>();

--- a/src/FungibleTokenStandard.ts
+++ b/src/FungibleTokenStandard.ts
@@ -35,13 +35,13 @@ import {
   EventTypes,
   ParameterTypes,
   FlagTypes,
+  MERKLE_HEIGHT,
 } from './configs.js';
 import { SideloadedProof } from './side-loaded/program.eg.js';
 
 const { IndexedMerkleMap } = Experimental;
 
-const height = 3;
-class VKeyMerkleMap extends IndexedMerkleMap(height) {}
+class VKeyMerkleMap extends IndexedMerkleMap(MERKLE_HEIGHT) {}
 
 export {
   FungibleTokenErrors,

--- a/src/FungibleTokenStandard.ts
+++ b/src/FungibleTokenStandard.ts
@@ -129,6 +129,8 @@ const FungibleTokenErrors = {
     'Method overridden: Use transferCustom() for side-loaded proof support instead of transfer()',
 };
 
+const MINA_TOKEN_ID = Field(1); // The native MINA token ID is always 1
+
 class FungibleToken extends TokenContract {
   @state(UInt8) decimals = State<UInt8>();
   @state(PublicKey) admin = State<PublicKey>();
@@ -1085,7 +1087,7 @@ class FungibleToken extends TokenContract {
     // Ensure the MINA account data uses native MINA.
     Provable.if(
       shouldVerify,
-      minaAccountData.tokenId.equals(1),
+      minaAccountData.tokenId.equals(MINA_TOKEN_ID),
       Bool(true)
     ).assertTrue(FungibleTokenErrors.incorrectMinaTokenId);
 

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -145,7 +145,7 @@ const BIT_SIZES = {
       UPDATES: 3,
     },
   },
-};
+} as const;
 
 /**
  * `AmountConfig` defines shared constraints for fixed and ranged value settings

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -190,7 +190,7 @@ class AmountConfig extends Struct({
    * @returns A packed `Field` combining both configs.
    */
   static packConfigs(configs: [AmountConfig, AmountConfig]): Field {
-    if (configs.length !== 2)
+    if (configs.length !== CONFIG_REQUIREMENTS.AMOUNT_CONFIG_COUNT)
       throw new Error(ConfigErrors.invalidAmountConfigCount);
     return Field.fromBits([...configs[0].toBits(), ...configs[1].toBits()]);
   }
@@ -647,7 +647,7 @@ class DynamicProofConfig extends Struct({
    * @returns Packed 24-bit Field.
    */
   static packConfigs(configs: DynamicProofConfig[]): Field {
-    if (configs.length !== 4)
+    if (configs.length !== CONFIG_REQUIREMENTS.DYNAMIC_PROOF_CONFIG_COUNT)
       throw new Error(ConfigErrors.invalidDynamicProofConfigCount);
 
     const bits = configs.flatMap((config) => config.toBits());

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -114,7 +114,7 @@ const FlagTypes = {
 };
 
 // The native MINA token ID is always 1
-const MINA_TOKEN_ID = Field(1);
+const MINA_TOKEN_ID = 1 as const;
 
 /**
  * Height of the Merkle tree used for verification key storage.

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -38,6 +38,21 @@ const ConfigErrors = {
 };
 
 /**
+ * Constants defining required sizes and counts for configurations
+ */
+const CONFIG_REQUIREMENTS = {
+  /**
+   * Number of dynamic proof configs in a complete set (mint, burn, transfer, updates)
+   */
+  DYNAMIC_PROOF_CONFIG_COUNT: 4,
+
+  /**
+   * Number of amount configs in a complete set (mint, burn)
+   */
+  AMOUNT_CONFIG_COUNT: 2,
+};
+
+/**
  * `OperationKeys` provides symbolic names for the different token operations
  * that can have associated side-loaded verification keys.
  *

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -230,12 +230,17 @@ class MintConfig extends AmountConfig {
    * @returns A new `Field` with updated mint config and preserved burn config.
    */
   updatePackedConfigs(packedConfigs: Field) {
-    const serializedConfigs = packedConfigs.toBits(6);
+    const serializedConfigs = packedConfigs.toBits(
+      BitSizes.AMOUNT_CONFIG.TOTAL_BITS
+    );
     const serializedMintConfig = this.toBits();
 
     const updatedPackedConfigs = Field.fromBits([
       ...serializedMintConfig,
-      ...serializedConfigs.slice(3, 6),
+      ...serializedConfigs.slice(
+        BitSizes.AMOUNT_CONFIG.BURN.START,
+        BitSizes.AMOUNT_CONFIG.BURN.END
+      ),
     ]);
 
     return updatedPackedConfigs;

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -15,6 +15,7 @@ export {
   EventTypes,
   ParameterTypes,
   FlagTypes,
+  MERKLE_HEIGHT,
 };
 
 /**

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -96,6 +96,11 @@ const FlagTypes = {
   Unauthorized: Field(3),
 };
 
+const BitSizes = {
+  totalAmountConfigsTotal: 6, // 3 bits for mint + 3 bits for burn
+  MintRange: {Start: 0, End: 3}, // Mint config bits 0-2
+  BurnRange: {Start: 3, End: 6}, // Burn config bits 3-5
+}
 
 /**
  * `AmountConfig` defines shared constraints for fixed and ranged value settings

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -97,9 +97,20 @@ const FlagTypes = {
 };
 
 const BitSizes = {
-  totalAmountConfigsTotal: 6, // 3 bits for mint + 3 bits for burn
-  MintRange: {Start: 0, End: 3}, // Mint config bits 0-2
-  BurnRange: {Start: 3, End: 6}, // Burn config bits 3-5
+  // Amount configs constants (MintConfig, BurnConfig)
+  AMOUNT_CONFIG: {
+    TOTAL_BITS: 6,
+    MINT: { START: 0, END: 3 },
+    BURN: { START: 3, END: 6 },
+  },
+
+  // Amount parameters constants (MintParams, BurnParams)
+  AMOUNT_PARAMS: {
+    TOTAL_BITS: 64 * 3,
+    FIXED_AMOUNT: { START: 0, END: 64 },
+    MIN_AMOUNT: { START: 64, END: 64 * 2 },
+    MAX_AMOUNT: { START: 64 * 2, END: 64 * 3 },
+  },
 }
 
 /**

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -303,11 +303,16 @@ class BurnConfig extends AmountConfig {
    * @returns A new `Field` with updated burn config and preserved mint config.
    */
   updatePackedConfigs(packedConfigs: Field) {
-    const serializedConfigs = packedConfigs.toBits(6);
+    const serializedConfigs = packedConfigs.toBits(
+      BitSizes.AMOUNT_CONFIG.TOTAL_BITS
+    );
     const serializedBurnConfig = this.toBits();
 
     const updatedPackedConfigs = Field.fromBits([
-      ...serializedConfigs.slice(0, 3),
+      ...serializedConfigs.slice(
+        BitSizes.AMOUNT_CONFIG.MINT.START,
+        BitSizes.AMOUNT_CONFIG.MINT.END
+      ),
       ...serializedBurnConfig,
     ]);
 

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -632,12 +632,14 @@ class DynamicProofConfig extends Struct({
    * @returns Updated 24-bit packed Field.
    */
   updatePackedConfigs(packedConfigs: Field, configIndex: number): Field {
-    const bits = packedConfigs.toBits(28);
-    const start = configIndex * 7;
+    const bits = packedConfigs.toBits(
+      BIT_SIZES.DYNAMIC_PROOF_CONFIG.TOTAL_BITS
+    );
+    const start = configIndex * BIT_SIZES.DYNAMIC_PROOF_CONFIG.BITS_PER_CONFIG;
     const updatedBits = [
       ...bits.slice(0, start),
       ...this.toBits(),
-      ...bits.slice(start + 7),
+      ...bits.slice(start + BIT_SIZES.DYNAMIC_PROOF_CONFIG.BITS_PER_CONFIG),
     ];
 
     return Field.fromBits(updatedBits);

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -118,7 +118,7 @@ const FlagTypes = {
  */
 const MERKLE_HEIGHT = 3;
 
-const BitSizes = {
+const BIT_SIZES = {
   // Amount configs constants (MintConfig, BurnConfig)
   AMOUNT_CONFIG: {
     TOTAL_BITS: 6,
@@ -228,10 +228,10 @@ class MintConfig extends AmountConfig {
    */
   static unpack(packedConfigs: Field) {
     const serializedMintConfig = packedConfigs
-      .toBits(BitSizes.AMOUNT_CONFIG.TOTAL_BITS)
+      .toBits(BIT_SIZES.AMOUNT_CONFIG.TOTAL_BITS)
       .slice(
-        BitSizes.AMOUNT_CONFIG.MINT.START,
-        BitSizes.AMOUNT_CONFIG.MINT.END
+        BIT_SIZES.AMOUNT_CONFIG.MINT.START,
+        BIT_SIZES.AMOUNT_CONFIG.MINT.END
       );
     const [unauthorized, fixedAmount, rangedAmount] = serializedMintConfig;
 
@@ -253,15 +253,15 @@ class MintConfig extends AmountConfig {
    */
   updatePackedConfigs(packedConfigs: Field) {
     const serializedConfigs = packedConfigs.toBits(
-      BitSizes.AMOUNT_CONFIG.TOTAL_BITS
+      BIT_SIZES.AMOUNT_CONFIG.TOTAL_BITS
     );
     const serializedMintConfig = this.toBits();
 
     const updatedPackedConfigs = Field.fromBits([
       ...serializedMintConfig,
       ...serializedConfigs.slice(
-        BitSizes.AMOUNT_CONFIG.BURN.START,
-        BitSizes.AMOUNT_CONFIG.BURN.END
+        BIT_SIZES.AMOUNT_CONFIG.BURN.START,
+        BIT_SIZES.AMOUNT_CONFIG.BURN.END
       ),
     ]);
 
@@ -301,10 +301,10 @@ class BurnConfig extends AmountConfig {
    */
   static unpack(packedConfigs: Field) {
     const serializedBurnConfig = packedConfigs
-      .toBits(BitSizes.AMOUNT_CONFIG.TOTAL_BITS)
+      .toBits(BIT_SIZES.AMOUNT_CONFIG.TOTAL_BITS)
       .slice(
-        BitSizes.AMOUNT_CONFIG.BURN.START,
-        BitSizes.AMOUNT_CONFIG.BURN.END
+        BIT_SIZES.AMOUNT_CONFIG.BURN.START,
+        BIT_SIZES.AMOUNT_CONFIG.BURN.END
       );
     const [unauthorized, fixedAmount, rangedAmount] = serializedBurnConfig;
 
@@ -326,14 +326,14 @@ class BurnConfig extends AmountConfig {
    */
   updatePackedConfigs(packedConfigs: Field) {
     const serializedConfigs = packedConfigs.toBits(
-      BitSizes.AMOUNT_CONFIG.TOTAL_BITS
+      BIT_SIZES.AMOUNT_CONFIG.TOTAL_BITS
     );
     const serializedBurnConfig = this.toBits();
 
     const updatedPackedConfigs = Field.fromBits([
       ...serializedConfigs.slice(
-        BitSizes.AMOUNT_CONFIG.MINT.START,
-        BitSizes.AMOUNT_CONFIG.MINT.END
+        BIT_SIZES.AMOUNT_CONFIG.MINT.START,
+        BIT_SIZES.AMOUNT_CONFIG.MINT.END
       ),
       ...serializedBurnConfig,
     ]);

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -122,8 +122,8 @@ const BitSizes = {
       TRANSFER: 2,
       UPDATES: 3,
     },
-    },
-}
+  },
+};
 
 /**
  * `AmountConfig` defines shared constraints for fixed and ranged value settings
@@ -205,7 +205,12 @@ class MintConfig extends AmountConfig {
    * @returns A `MintConfig` instance constructed from the first 3 bits of the field.
    */
   static unpack(packedConfigs: Field) {
-    const serializedMintConfig = packedConfigs.toBits(6).slice(0, 3);
+    const serializedMintConfig = packedConfigs
+      .toBits(BitSizes.AMOUNT_CONFIG.TOTAL_BITS)
+      .slice(
+        BitSizes.AMOUNT_CONFIG.MINT.START,
+        BitSizes.AMOUNT_CONFIG.MINT.END
+      );
     const [unauthorized, fixedAmount, rangedAmount] = serializedMintConfig;
 
     return new this({

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -16,6 +16,7 @@ export {
   ParameterTypes,
   FlagTypes,
   MERKLE_HEIGHT,
+  MINA_TOKEN_ID,
 };
 
 /**
@@ -111,6 +112,9 @@ const FlagTypes = {
   RangedAmount: Field(2),
   Unauthorized: Field(3),
 };
+
+// The native MINA token ID is always 1
+const MINA_TOKEN_ID = Field(1);
 
 /**
  * Height of the Merkle tree used for verification key storage.

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -15,7 +15,6 @@ export {
   EventTypes,
   ParameterTypes,
   FlagTypes,
-  MINA_TOKEN_ID
 };
 
 /**
@@ -97,7 +96,6 @@ const FlagTypes = {
   Unauthorized: Field(3),
 };
 
-const MINA_TOKEN_ID = Field(0);
 
 /**
  * `AmountConfig` defines shared constraints for fixed and ranged value settings

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -278,7 +278,12 @@ class BurnConfig extends AmountConfig {
    * @returns A `BurnConfig` instance constructed from bits 3–5.
    */
   static unpack(packedConfigs: Field) {
-    const serializedBurnConfig = packedConfigs.toBits(6).slice(3, 6);
+    const serializedBurnConfig = packedConfigs
+      .toBits(BitSizes.AMOUNT_CONFIG.TOTAL_BITS)
+      .slice(
+        BitSizes.AMOUNT_CONFIG.BURN.START,
+        BitSizes.AMOUNT_CONFIG.BURN.END
+      );
     const [unauthorized, fixedAmount, rangedAmount] = serializedBurnConfig;
 
     return new this({

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -609,8 +609,10 @@ class DynamicProofConfig extends Struct({
    * @returns A DynamicProofConfig instance.
    */
   static unpack(packedConfigs: Field, configIndex: number) {
-    const start = configIndex * 7;
-    const bits = packedConfigs.toBits(28).slice(start, start + 7);
+    const start = configIndex * BIT_SIZES.DYNAMIC_PROOF_CONFIG.BITS_PER_CONFIG;
+    const bits = packedConfigs
+      .toBits(BIT_SIZES.DYNAMIC_PROOF_CONFIG.TOTAL_BITS)
+      .slice(start, start + BIT_SIZES.DYNAMIC_PROOF_CONFIG.BITS_PER_CONFIG);
 
     return new this({
       shouldVerify: bits[0],

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -111,6 +111,18 @@ const BitSizes = {
     MIN_AMOUNT: { START: 64, END: 64 * 2 },
     MAX_AMOUNT: { START: 64 * 2, END: 64 * 3 },
   },
+
+  // Dynamic proof config constants
+  DYNAMIC_PROOF_CONFIG: {
+    TOTAL_BITS: 28,
+    BITS_PER_CONFIG: 7,
+    INDICES: {
+      MINT: 0,
+      BURN: 1,
+      TRANSFER: 2,
+      UPDATES: 3,
+    },
+    },
 }
 
 /**

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -399,11 +399,26 @@ class AmountParams extends Struct({
    * @returns A new AmountParams instance with the unpacked fixed, minimum, and maximum amounts.
    */
   static unpack(packedParams: Field) {
-    const bits = packedParams.toBits(64 * 3);
+    const bits = packedParams.toBits(BIT_SIZES.AMOUNT_PARAMS.TOTAL_BITS);
     return new this({
-      fixedAmount: UInt64.fromBits(bits.slice(0, 64)),
-      minAmount: UInt64.fromBits(bits.slice(64, 64 * 2)),
-      maxAmount: UInt64.fromBits(bits.slice(64 * 2, 64 * 3)),
+      fixedAmount: UInt64.fromBits(
+        bits.slice(
+          BIT_SIZES.AMOUNT_PARAMS.FIXED_AMOUNT.START,
+          BIT_SIZES.AMOUNT_PARAMS.FIXED_AMOUNT.END
+        )
+      ),
+      minAmount: UInt64.fromBits(
+        bits.slice(
+          BIT_SIZES.AMOUNT_PARAMS.MIN_AMOUNT.START,
+          BIT_SIZES.AMOUNT_PARAMS.MIN_AMOUNT.END
+        )
+      ),
+      maxAmount: UInt64.fromBits(
+        bits.slice(
+          BIT_SIZES.AMOUNT_PARAMS.MAX_AMOUNT.START,
+          BIT_SIZES.AMOUNT_PARAMS.MAX_AMOUNT.END
+        )
+      ),
     });
   }
 

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -96,6 +96,12 @@ const FlagTypes = {
   Unauthorized: Field(3),
 };
 
+/**
+ * Height of the Merkle tree used for verification key storage.
+ * Used to configure the IndexedMerkleMap for VKeyMerkleMap.
+ */
+const MERKLE_HEIGHT = 3;
+
 const BitSizes = {
   // Amount configs constants (MintConfig, BurnConfig)
   AMOUNT_CONFIG: {

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -15,6 +15,7 @@ export {
   EventTypes,
   ParameterTypes,
   FlagTypes,
+  MINA_TOKEN_ID
 };
 
 /**
@@ -95,6 +96,8 @@ const FlagTypes = {
   RangedAmount: Field(2),
   Unauthorized: Field(3),
 };
+
+const MINA_TOKEN_ID = Field(0);
 
 /**
  * `AmountConfig` defines shared constraints for fixed and ranged value settings


### PR DESCRIPTION
## Description
This PR refactors the codebase to use predefined constants instead of hard-coded values

## Changes
The following were created to predefined constants
- Bit manipulation values 
- The MINA token ID 
- Merkle tree configuration
- Array length validation
