### PR TITLE
Fix Broken Example File Reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ node build/src/examples/e2e.eg.js
 # Run the escrow example
 node build/src/examples/escrow.eg.js
 
-# Run the concurrent transfer example
-node build/src/examples/e2e.eg.js
+# Run the token manager example
+node build/src/examples/token-manager.eg.js
 ```
 
 ## Technical Limitations & Best Practices

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ node build/src/examples/e2e.eg.js
 node build/src/examples/escrow.eg.js
 
 # Run the concurrent transfer example
-node build/src/examples/concurrent-transfer.eg.js
+node build/src/examples/e2e.eg.js
 ```
 
 ## Technical Limitations & Best Practices


### PR DESCRIPTION
We removed the `concurrent-transfer` example because it was running on Devnet and failing multiple times. 
This PR updates the README for referencing another example (`token-manager`) instead of the `concurrent-transfer` example