### PR TITLE
Extract Event Classes to a Separate File

### DIFF
--- a/src/FungibleTokenContract.ts
+++ b/src/FungibleTokenContract.ts
@@ -39,6 +39,20 @@ import {
   MINA_TOKEN_ID,
 } from './configs.js';
 import { SideloadedProof } from './side-loaded/program.eg.js';
+import {
+  SetAdminEvent,
+  MintEvent,
+  BurnEvent,
+  TransferEvent,
+  BalanceChangeEvent,
+  InitializationEvent,
+  VerificationKeyUpdateEvent,
+  SideLoadedVKeyUpdateEvent,
+  ConfigStructureUpdateEvent,
+  AmountValueUpdateEvent,
+  DynamicProofConfigUpdateEvent,
+  ConfigFlagUpdateEvent,
+} from './events.js';
 
 // =============================================================================
 // EXPORTS
@@ -47,15 +61,16 @@ import { SideloadedProof } from './side-loaded/program.eg.js';
 export {
   FungibleTokenErrors,
   FungibleToken,
+  VKeyMerkleMap,
+  // Re-export all events from events.js
   SetAdminEvent,
   MintEvent,
   BurnEvent,
   TransferEvent,
   BalanceChangeEvent,
-  VKeyMerkleMap,
-  SideLoadedVKeyUpdateEvent,
   InitializationEvent,
   VerificationKeyUpdateEvent,
+  SideLoadedVKeyUpdateEvent,
   ConfigStructureUpdateEvent,
   AmountValueUpdateEvent,
   DynamicProofConfigUpdateEvent,
@@ -149,111 +164,6 @@ const FungibleTokenErrors = {
   useCustomTransferMethod:
     'Method overridden: Use transferCustom() for side-loaded proof support instead of transfer()',
 };
-
-// =============================================================================
-// EVENT CLASSES
-// =============================================================================
-
-/**
- * Event emitted when the admin is changed.
- */
-class SetAdminEvent extends Struct({
-  previousAdmin: PublicKey,
-  newAdmin: PublicKey,
-}) {}
-
-/**
- * Event emitted when tokens are minted.
- */
-class MintEvent extends Struct({
-  recipient: PublicKey,
-  amount: UInt64,
-}) {}
-
-/**
- * Event emitted when tokens are burned.
- */
-class BurnEvent extends Struct({
-  from: PublicKey,
-  amount: UInt64,
-}) {}
-
-/**
- * Event emitted when a balance change occurs.
- */
-class BalanceChangeEvent extends Struct({
-  address: PublicKey,
-  amount: Int64,
-}) {}
-
-/**
- * Event emitted when a side-loaded verification key is updated.
- */
-class SideLoadedVKeyUpdateEvent extends Struct({
-  operationKey: Field,
-  newVKeyHash: Field,
-  newMerkleRoot: Field,
-}) {}
-
-/**
- * Event emitted when tokens are transferred.
- */
-class TransferEvent extends Struct({
-  from: PublicKey,
-  to: PublicKey,
-  amount: UInt64,
-}) {}
-
-/**
- * Event emitted when the contract is initialized.
- */
-class InitializationEvent extends Struct({
-  admin: PublicKey,
-  decimals: UInt8,
-}) {}
-
-/**
- * Event emitted when the verification key is updated.
- */
-class VerificationKeyUpdateEvent extends Struct({
-  vKeyHash: Field,
-}) {}
-
-/**
- * Event emitted when configuration structure is updated.
- */
-class ConfigStructureUpdateEvent extends Struct({
-  updateType: Field, // EventTypes.Config or EventTypes.Params
-  category: Field, // OperationKeys.Mint or OperationKeys.Burn
-}) {}
-
-/**
- * Event emitted when amount parameters are updated.
- */
-class AmountValueUpdateEvent extends Struct({
-  parameterType: Field, // ParameterTypes.FixedAmount, MinAmount, or MaxAmount
-  category: Field, // OperationKeys.Mint or OperationKeys.Burn
-  oldValue: UInt64,
-  newValue: UInt64,
-}) {}
-
-/**
- * Event emitted when dynamic proof configuration is updated.
- */
-class DynamicProofConfigUpdateEvent extends Struct({
-  operationType: Field, // OperationKeys.Mint, Burn, Transfer, or ApproveBase
-  newConfig: Field, // The updated packed configuration
-}) {}
-
-/**
- * Event emitted when configuration flags are updated.
- */
-class ConfigFlagUpdateEvent extends Struct({
-  flagType: Field, // FlagTypes.FixedAmount, RangedAmount, or Unauthorized
-  category: Field, // OperationKeys.Mint or OperationKeys.Burn
-  oldValue: Bool,
-  newValue: Bool,
-}) {}
 
 // =============================================================================
 // MAIN CONTRACT CLASS

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,114 @@
+import { Bool, Field, Int64, PublicKey, Struct, UInt64, UInt8 } from 'o1js';
+
+// =============================================================================
+// TOKEN EVENT CLASSES
+// =============================================================================
+
+/**
+ * Event emitted when the admin is changed.
+ */
+export class SetAdminEvent extends Struct({
+  previousAdmin: PublicKey,
+  newAdmin: PublicKey,
+}) {}
+
+/**
+ * Event emitted when tokens are minted.
+ */
+export class MintEvent extends Struct({
+  recipient: PublicKey,
+  amount: UInt64,
+}) {}
+
+/**
+ * Event emitted when tokens are burned.
+ */
+export class BurnEvent extends Struct({
+  from: PublicKey,
+  amount: UInt64,
+}) {}
+
+/**
+ * Event emitted when tokens are transferred.
+ */
+export class TransferEvent extends Struct({
+  from: PublicKey,
+  to: PublicKey,
+  amount: UInt64,
+}) {}
+
+/**
+ * Event emitted when a balance change occurs.
+ */
+export class BalanceChangeEvent extends Struct({
+  address: PublicKey,
+  amount: Int64,
+}) {}
+
+// =============================================================================
+// ADMINISTRATIVE EVENT CLASSES
+// =============================================================================
+
+/**
+ * Event emitted when the contract is initialized.
+ */
+export class InitializationEvent extends Struct({
+  admin: PublicKey,
+  decimals: UInt8,
+}) {}
+
+/**
+ * Event emitted when the verification key is updated.
+ */
+export class VerificationKeyUpdateEvent extends Struct({
+  vKeyHash: Field,
+}) {}
+
+/**
+ * Event emitted when a side-loaded verification key is updated.
+ */
+export class SideLoadedVKeyUpdateEvent extends Struct({
+  operationKey: Field,
+  newVKeyHash: Field,
+  newMerkleRoot: Field,
+}) {}
+
+// =============================================================================
+// CONFIGURATION EVENT CLASSES
+// =============================================================================
+
+/**
+ * Event emitted when configuration structure is updated.
+ */
+export class ConfigStructureUpdateEvent extends Struct({
+  updateType: Field, // EventTypes.Config or EventTypes.Params
+  category: Field, // OperationKeys.Mint or OperationKeys.Burn
+}) {}
+
+/**
+ * Event emitted when amount parameters are updated.
+ */
+export class AmountValueUpdateEvent extends Struct({
+  parameterType: Field, // ParameterTypes.FixedAmount, MinAmount, or MaxAmount
+  category: Field, // OperationKeys.Mint or OperationKeys.Burn
+  oldValue: UInt64,
+  newValue: UInt64,
+}) {}
+
+/**
+ * Event emitted when dynamic proof configuration is updated.
+ */
+export class DynamicProofConfigUpdateEvent extends Struct({
+  operationType: Field, // OperationKeys.Mint, Burn, Transfer, or ApproveBase
+  newConfig: Field, // The updated packed configuration
+}) {}
+
+/**
+ * Event emitted when configuration flags are updated.
+ */
+export class ConfigFlagUpdateEvent extends Struct({
+  flagType: Field, // FlagTypes.FixedAmount, RangedAmount, or Unauthorized
+  category: Field, // OperationKeys.Mint or OperationKeys.Burn
+  oldValue: Bool,
+  newValue: Bool,
+}) {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,16 +11,26 @@ export {
   OperationKeys,
 } from './configs.js';
 
-export { 
-    FungibleTokenErrors,
-    FungibleToken,
-    SetAdminEvent,
-    MintEvent,
-    BurnEvent,
-    BalanceChangeEvent,
-    SideLoadedVKeyUpdateEvent,
-    VKeyMerkleMap,
+export {
+  FungibleTokenErrors,
+  FungibleToken,
+  VKeyMerkleMap,
 } from './FungibleTokenContract.js';
+
+export {
+  SetAdminEvent,
+  MintEvent,
+  BurnEvent,
+  TransferEvent,
+  BalanceChangeEvent,
+  InitializationEvent,
+  VerificationKeyUpdateEvent,
+  SideLoadedVKeyUpdateEvent,
+  ConfigStructureUpdateEvent,
+  AmountValueUpdateEvent,
+  DynamicProofConfigUpdateEvent,
+  ConfigFlagUpdateEvent,
+} from './events.js';
 
 export {
   generateDummyDynamicProof,


### PR DESCRIPTION
## Description
This PR is for moving events from the fungible token contract to a separate file for better readability.

## Changes
- Created a new file called `src/events.ts` 
- Moved all of the event classes in the new file

Tests pass with `proofsEnabled=true`