### PR TITLE
Standardize Side-Loaded Proof Interfaces and Relocate Examples

### DIFF
--- a/src/FungibleTokenContract.ts
+++ b/src/FungibleTokenContract.ts
@@ -38,7 +38,7 @@ import {
   MERKLE_HEIGHT,
   MINA_TOKEN_ID,
 } from './lib/configs.js';
-import { SideloadedProof } from './side-loaded/program.eg.js';
+import { SideloadedProof } from './lib/sideloaded.js';
 import { FungibleTokenErrors } from './lib/errors.js';
 import {
   SetAdminEvent,

--- a/src/examples/e2e.eg.ts
+++ b/src/examples/e2e.eg.ts
@@ -4,7 +4,7 @@ import { VerificationKey } from 'o1js';
 import {
   generateDummyDynamicProof,
   SideloadedProof,
-} from '../side-loaded/program.eg.js';
+} from './side-loaded/program.eg.js';
 import {
   MintConfig,
   MintParams,

--- a/src/examples/escrow.eg.ts
+++ b/src/examples/escrow.eg.ts
@@ -28,7 +28,7 @@ import {
 import {
   generateDummyDynamicProof,
   SideloadedProof,
-} from '../side-loaded/program.eg.js';
+} from './side-loaded/program.eg.js';
 import { FungibleToken, VKeyMerkleMap } from '../FungibleTokenContract.js';
 
 export class TokenEscrow extends SmartContract {

--- a/src/examples/run.ts
+++ b/src/examples/run.ts
@@ -1,6 +1,6 @@
 import { equal } from 'node:assert';
 import { AccountUpdate, Bool, Mina, PrivateKey, UInt64, UInt8 } from 'o1js';
-import { FungibleToken, VKeyMerkleMap } from './FungibleTokenContract.js';
+import { FungibleToken, VKeyMerkleMap } from '../FungibleTokenContract.js';
 import {
   MintConfig,
   MintParams,
@@ -10,7 +10,7 @@ import {
   BurnDynamicProofConfig,
   TransferDynamicProofConfig,
   UpdatesDynamicProofConfig,
-} from './lib/configs.js';
+} from '../lib/configs.js';
 import {
   generateDummyDynamicProof,
   program,

--- a/src/examples/side-loaded/program.eg.ts
+++ b/src/examples/side-loaded/program.eg.ts
@@ -1,13 +1,12 @@
 import {
   ZkProgram,
   Field,
-  DynamicProof,
-  Struct,
   AccountUpdate,
   PublicKey,
   UInt64,
   UInt32,
 } from 'o1js';
+import { PublicInputs, PublicOutputs, SideloadedProof } from '../../lib/sideloaded.js';
 
 export {
   program,
@@ -21,20 +20,6 @@ export {
   Program2Proof,
   generateDynamicProof2,
 };
-
-class PublicInputs extends Struct({
-  tokenId: Field,
-  address: PublicKey,
-}) {}
-
-class PublicOutputs extends Struct({
-  minaAccountData: AccountUpdate,
-  tokenIdAccountData: AccountUpdate,
-  minaBalance: UInt64,
-  tokenIdBalance: UInt64,
-  minaNonce: UInt32,
-  tokenIdNonce: UInt32,
-}) {}
 
 const program = ZkProgram({
   name: 'approve-mint',
@@ -77,12 +62,6 @@ const program = ZkProgram({
 });
 
 class ProgramProof extends ZkProgram.Proof(program) {}
-
-class SideloadedProof extends DynamicProof<PublicInputs, PublicOutputs> {
-  static publicInputType = PublicInputs;
-  static publicOutputType = PublicOutputs;
-  static maxProofsVerified = 0 as const;
-}
 
 // ---------------------- UTILS ----------------------------
 

--- a/src/examples/side-loaded/run.ts
+++ b/src/examples/side-loaded/run.ts
@@ -9,7 +9,7 @@ import {
   UInt64,
   UInt8,
 } from 'o1js';
-import { FungibleToken, VKeyMerkleMap } from '../FungibleTokenContract.js';
+import { FungibleToken, VKeyMerkleMap } from '../../FungibleTokenContract.js';
 import {
   MintConfig,
   MintParams,
@@ -20,7 +20,7 @@ import {
   TransferDynamicProofConfig,
   UpdatesDynamicProofConfig,
   OperationKeys,
-} from '../lib/configs.js';
+} from '../../lib/configs.js';
 import {
   program,
   generateDummyDynamicProof,

--- a/src/examples/token-manager.eg.ts
+++ b/src/examples/token-manager.eg.ts
@@ -25,7 +25,7 @@ import { FungibleToken, VKeyMerkleMap } from '../FungibleTokenContract.js';
 import {
   generateDummyDynamicProof,
   SideloadedProof,
-} from '../side-loaded/program.eg.js';
+} from './side-loaded/program.eg.js';
 import {
   BurnConfig,
   BurnDynamicProofConfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export {
 export {
   generateDummyDynamicProof,
   SideloadedProof,
-} from './side-loaded/program.eg.js';
+} from './examples/side-loaded/program.eg.js';
 
 export type {
   TokenAdmin,

--- a/src/interfaces/SideloadedTokenContract.ts
+++ b/src/interfaces/SideloadedTokenContract.ts
@@ -6,7 +6,7 @@ import {
   AccountUpdateForest,
   VerificationKey,
 } from 'o1js';
-import { SideloadedProof } from '../side-loaded/program.eg.js';
+import { SideloadedProof } from '../lib/sideloaded.js';
 import { VKeyMerkleMap } from '../FungibleTokenContract.js';
 
 /**

--- a/src/lib/sideloaded.ts
+++ b/src/lib/sideloaded.ts
@@ -1,0 +1,43 @@
+import {
+  DynamicProof,
+  Field,
+  PublicKey,
+  Struct,
+  AccountUpdate,
+  UInt64,
+  UInt32,
+} from 'o1js';
+
+export { PublicInputs, PublicOutputs, SideloadedProof };
+
+/**
+ * Standard public inputs for side-loaded proofs.
+ * Defines the expected input structure for validation.
+ */
+class PublicInputs extends Struct({
+  tokenId: Field,
+  address: PublicKey,
+}) {}
+
+/**
+ * Standard public outputs for side-loaded proofs.
+ * Defines the expected output structure containing account data and balances.
+ */
+class PublicOutputs extends Struct({
+  minaAccountData: AccountUpdate,
+  tokenIdAccountData: AccountUpdate,
+  minaBalance: UInt64,
+  tokenIdBalance: UInt64,
+  minaNonce: UInt32,
+  tokenIdNonce: UInt32,
+}) {}
+
+/**
+ * Standard side-loaded proof class for dynamic proof verification.
+ * This defines the interface that all side-loaded proofs must implement.
+ */
+class SideloadedProof extends DynamicProof<PublicInputs, PublicOutputs> {
+  static publicInputType = PublicInputs;
+  static publicOutputType = PublicOutputs;
+  static maxProofsVerified = 0 as const;
+} 

--- a/src/test/approve.test.ts
+++ b/src/test/approve.test.ts
@@ -38,7 +38,7 @@ import {
   program2,
   PublicInputs,
   PublicOutputs,
-} from '../side-loaded/program.eg.js';
+} from '../examples/side-loaded/program.eg.js';
 import { TEST_ERROR_MESSAGES } from './constants.js';
 
 const proofsEnabled = false;
@@ -480,7 +480,7 @@ describe('Fungible Token - ApproveBase Tests', () => {
       );
     });
 
-    it('should reject manually constructed transfers from the account that\'s tracking circulation', async () => {
+    it("should reject manually constructed transfers from the account that's tracking circulation", async () => {
       const sendAmount = UInt64.from(10);
 
       const updateSend = AccountUpdate.createSigned(
@@ -518,7 +518,7 @@ describe('Fungible Token - ApproveBase Tests', () => {
       );
     });
 
-    it('should reject manually constructed transfers to the account that\'s tracking circulation', async () => {
+    it("should reject manually constructed transfers to the account that's tracking circulation", async () => {
       const sendAmount = UInt64.from(10);
 
       const updateSend = AccountUpdate.createSigned(
@@ -688,7 +688,7 @@ describe('Fungible Token - ApproveBase Tests', () => {
       );
     });
 
-    it('should reject manually constructed transfers from the account that\'s tracking circulation using sideload-disabled method', async () => {
+    it("should reject manually constructed transfers from the account that's tracking circulation using sideload-disabled method", async () => {
       const sendAmount = UInt64.from(10);
 
       const updateSend = AccountUpdate.createSigned(
@@ -724,7 +724,7 @@ describe('Fungible Token - ApproveBase Tests', () => {
       );
     });
 
-    it('should reject manually constructed transfers to the account that\'s tracking circulation using sideload-disabled method', async () => {
+    it("should reject manually constructed transfers to the account that's tracking circulation using sideload-disabled method", async () => {
       const sendAmount = UInt64.from(10);
 
       const updateSend = AccountUpdate.createSigned(
@@ -762,7 +762,7 @@ describe('Fungible Token - ApproveBase Tests', () => {
   });
 
   describe('Account Permissions', () => {
-    it('should reject a transaction that\'s changing the account permission for receive', async () => {
+    it("should reject a transaction that's changing the account permission for receive", async () => {
       const permissions = Mina.getAccount(
         user2,
         tokenContract.deriveTokenId()
@@ -797,7 +797,7 @@ describe('Fungible Token - ApproveBase Tests', () => {
         FungibleTokenErrors.noPermissionChangeAllowed
       );
     });
-    it('should reject a transaction that\'s changing the account permission for receive with approveBaseSideloadDisabled', async () => {
+    it("should reject a transaction that's changing the account permission for receive with approveBaseSideloadDisabled", async () => {
       const permissions = Mina.getAccount(
         user2,
         tokenContract.deriveTokenId()
@@ -849,7 +849,8 @@ describe('Fungible Token - ApproveBase Tests', () => {
         await updateUpdatesDynamicProofConfigTx.prove();
         await updateUpdatesDynamicProofConfigTx.sign([user2.key]).send().wait();
       } catch (error: unknown) {
-        const expectedErrorMessage = TEST_ERROR_MESSAGES.NO_AUTHORIZATION_PROVIDED;
+        const expectedErrorMessage =
+          TEST_ERROR_MESSAGES.NO_AUTHORIZATION_PROVIDED;
         expect((error as Error).message).toContain(expectedErrorMessage);
       }
     });
@@ -877,7 +878,8 @@ describe('Fungible Token - ApproveBase Tests', () => {
 
   describe('Side-loaded Verification Key Updates', () => {
     it('should reject updating sideloaded verification key hash: unauthorized by admin', async () => {
-      const expectedErrorMessage = TEST_ERROR_MESSAGES.NO_AUTHORIZATION_PROVIDED;
+      const expectedErrorMessage =
+        TEST_ERROR_MESSAGES.NO_AUTHORIZATION_PROVIDED;
       await updateSLVkeyHashTx(
         user1,
         programVkey,

--- a/src/test/burn.test.ts
+++ b/src/test/burn.test.ts
@@ -36,7 +36,7 @@ import {
   generateDynamicProof2,
   SideloadedProof,
   program2,
-} from '../side-loaded/program.eg.js';
+} from '../examples/side-loaded/program.eg.js';
 import {
   CONFIG_PROPERTIES,
   PARAMS_PROPERTIES,

--- a/src/test/mint.test.ts
+++ b/src/test/mint.test.ts
@@ -36,7 +36,7 @@ import {
   generateDynamicProof2,
   SideloadedProof,
   program2,
-} from '../side-loaded/program.eg.js';
+} from '../examples/side-loaded/program.eg.js';
 import {
   CONFIG_PROPERTIES,
   PARAMS_PROPERTIES,

--- a/src/test/transfer.test.ts
+++ b/src/test/transfer.test.ts
@@ -32,7 +32,7 @@ import {
   generateDynamicProof2,
   SideloadedProof,
   program2,
-} from '../side-loaded/program.eg.js';
+} from '../examples/side-loaded/program.eg.js';
 import { TEST_ERROR_MESSAGES } from './constants.js';
 
 const proofsEnabled = false;
@@ -322,7 +322,8 @@ describe('Fungible Token - Transfer Tests', () => {
 
     it('should reject a transaction not signed by the token holder using sideload-disabled method', async () => {
       const transferAmount = UInt64.from(100);
-      const expectedErrorMessage = TEST_ERROR_MESSAGES.INVALID_SIGNATURE_FEE_PAYER;
+      const expectedErrorMessage =
+        TEST_ERROR_MESSAGES.INVALID_SIGNATURE_FEE_PAYER;
       await testTransferSideloadDisabledTx(
         user1,
         user3,
@@ -332,7 +333,7 @@ describe('Fungible Token - Transfer Tests', () => {
       );
     });
 
-    it('should prevent transfers from account that\'s tracking circulation', async () => {
+    it("should prevent transfers from account that's tracking circulation", async () => {
       const transferAmount = UInt64.from(100);
       const expectedErrorMessage =
         FungibleTokenErrors.noTransferFromCirculation;
@@ -345,7 +346,7 @@ describe('Fungible Token - Transfer Tests', () => {
       );
     });
 
-    it('should prevent transfers from account that\'s tracking circulation using sideload-disabled method', async () => {
+    it("should prevent transfers from account that's tracking circulation using sideload-disabled method", async () => {
       const transferAmount = UInt64.from(100);
       const expectedErrorMessage =
         FungibleTokenErrors.noTransferFromCirculation;
@@ -358,7 +359,7 @@ describe('Fungible Token - Transfer Tests', () => {
       );
     });
 
-    it('should prevent transfers to account that\'s tracking circulation', async () => {
+    it("should prevent transfers to account that's tracking circulation", async () => {
       const transferAmount = UInt64.from(100);
       const expectedErrorMessage =
         FungibleTokenErrors.noTransferFromCirculation;
@@ -371,7 +372,7 @@ describe('Fungible Token - Transfer Tests', () => {
       );
     });
 
-    it('should prevent transfers to account that\'s tracking circulation using sideload-disabled method', async () => {
+    it("should prevent transfers to account that's tracking circulation using sideload-disabled method", async () => {
       const transferAmount = UInt64.from(100);
       const expectedErrorMessage =
         FungibleTokenErrors.noTransferFromCirculation;
@@ -406,7 +407,8 @@ describe('Fungible Token - Transfer Tests', () => {
           .send()
           .wait();
       } catch (error: unknown) {
-        const expectedErrorMessage = TEST_ERROR_MESSAGES.NO_AUTHORIZATION_PROVIDED;
+        const expectedErrorMessage =
+          TEST_ERROR_MESSAGES.NO_AUTHORIZATION_PROVIDED;
         expect((error as Error).message).toContain(expectedErrorMessage);
       }
     });
@@ -434,7 +436,8 @@ describe('Fungible Token - Transfer Tests', () => {
 
   describe('Side-loaded Verification Key Updates', () => {
     it('should reject updating sideloaded verification key hash: unauthorized by admin', async () => {
-      const expectedErrorMessage = TEST_ERROR_MESSAGES.NO_AUTHORIZATION_PROVIDED;
+      const expectedErrorMessage =
+        TEST_ERROR_MESSAGES.NO_AUTHORIZATION_PROVIDED;
       await updateSLVkeyHashTx(
         user1,
         programVkey,


### PR DESCRIPTION
## Description
This PR fixes architectural issue where the main contract was importing from example code by extracting standard interfaces and properly organizing the examples directory structure.

## Changes
- Moved `PublicInputs`, `PublicOutputs`, `SideloadedProof` to `src/lib/sideloaded.ts`. Main contract now imports from `lib/` instead of `program.eg.ts`
- Moved `side-loaded` folder under `examples`
- Moved `run.ts` file under `examples`
- Updated import paths accordingly
- Formatting

Tests pass with `proofsEnabled=true`