### PR TITLE
Add `getAdmin()` Method to Retrieve Fungible Token Admin

### DIFF
--- a/src/CoreFungibleToken.ts
+++ b/src/CoreFungibleToken.ts
@@ -88,7 +88,6 @@ export class CoreToken {
     );
   }
 
-  // Approval methods
   async approveAccountUpdateCustom(
     accountUpdate: AccountUpdate | AccountUpdateTree
   ) {
@@ -115,5 +114,9 @@ export class CoreToken {
 
   async getDecimals() {
     return await this.token.getDecimals();
+  }
+
+  async getAdmin() {
+    return await this.token.getAdmin();
   }
 }

--- a/src/FungibleTokenContract.ts
+++ b/src/FungibleTokenContract.ts
@@ -845,6 +845,11 @@ class FungibleToken extends TokenContract implements TokenAdmin, TokenConfig, Si
     return this.decimals.getAndRequireEquals();
   }
 
+  @method.returns(PublicKey)
+  async getAdmin(): Promise<PublicKey> {
+    return this.admin.getAndRequireEquals();
+  }
+
   /**
    * Retrieves all current token configurations in packed form.
    * Caller can unpack off-chain using respective unpack methods.

--- a/src/test/mint.test.ts
+++ b/src/test/mint.test.ts
@@ -540,6 +540,11 @@ describe('Fungible Token - Mint Tests', () => {
       expect(unpackedBurnParams.minAmount).toEqual(burnParams.minAmount);
       expect(unpackedBurnParams.maxAmount).toEqual(burnParams.maxAmount);
     });
+
+    it('should return correct admin after initialization', async () => {
+      const currentAdmin = await tokenContract.getAdmin();
+      expect(currentAdmin.toBase58()).toEqual(tokenAdmin.toBase58());
+    });
   });
 
   describe('Mint Operations - Default Config (Authorized/Ranged)', () => {


### PR DESCRIPTION
## Description
This PR adds a new `getAdmin()` method to both `FungibleToken` and `CoreFungibleToken` classes to provide a standardized way to retrieve the current contract admin.

## Changes
- Added `@method.returns(PublicKey) async getAdmin()` method in `FungibleTokenContract`
- Added corresponding `async getAdmin()` wrapper method in `CoreFungibleToken`  
- Added test case to verify correct admin retrieval after initialization in `mint.test.ts`

Tests pass with `proofsEnabled=true`
