### PR TITLE
Optional params for initialize

### DIFF
--- a/src/FungibleTokenContract.ts
+++ b/src/FungibleTokenContract.ts
@@ -181,10 +181,10 @@ class FungibleToken extends TokenContract {
     mintParams: MintParams,
     burnConfig: BurnConfig,
     burnParams: BurnParams,
-    mintDynamicProofConfig: MintDynamicProofConfig,
-    burnDynamicProofConfig: BurnDynamicProofConfig,
-    transferDynamicProofConfig: TransferDynamicProofConfig,
-    updatesDynamicProofConfig: UpdatesDynamicProofConfig
+    mintDynamicProofConfig: MintDynamicProofConfig = MintDynamicProofConfig.default,
+    burnDynamicProofConfig: BurnDynamicProofConfig = BurnDynamicProofConfig.default,
+    transferDynamicProofConfig: TransferDynamicProofConfig = TransferDynamicProofConfig.default,
+    updatesDynamicProofConfig: UpdatesDynamicProofConfig = UpdatesDynamicProofConfig.default
   ) {
     this.account.provedState.requireEquals(Bool(false));
 

--- a/src/examples/e2e.eg.ts
+++ b/src/examples/e2e.eg.ts
@@ -76,11 +76,7 @@ const deployTx = await Mina.transaction({ sender: deployer, fee }, async () => {
     MintConfig.default,
     mintParams,
     burnConfig,
-    burnParams,
-    MintDynamicProofConfig.default,
-    BurnDynamicProofConfig.default,
-    TransferDynamicProofConfig.default,
-    UpdatesDynamicProofConfig.default
+    burnParams
   );
 });
 

--- a/src/examples/escrow.eg.ts
+++ b/src/examples/escrow.eg.ts
@@ -145,11 +145,7 @@ const deployTx = await Mina.transaction(
       MintConfig.default,
       mintParams,
       BurnConfig.default,
-      burnParams,
-      MintDynamicProofConfig.default,
-      BurnDynamicProofConfig.default,
-      TransferDynamicProofConfig.default,
-      UpdatesDynamicProofConfig.default
+      burnParams
     );
   }
 );

--- a/src/examples/token-manager.eg.ts
+++ b/src/examples/token-manager.eg.ts
@@ -198,11 +198,7 @@ const deployTx = await Mina.transaction(
         fixedAmount: UInt64.from(100),
         minAmount: UInt64.from(20),
         maxAmount: UInt64.MAXINT(),
-      }),
-      MintDynamicProofConfig.default,
-      BurnDynamicProofConfig.default,
-      TransferDynamicProofConfig.default,
-      UpdatesDynamicProofConfig.default
+      })
     );
   }
 );


### PR DESCRIPTION
Use the default (no proof) values for proof config if no params are given.

I removed the proof config options from the examples.