### PR TITLE
Update Interface Imports Paths After File Reorg

### DIFF
--- a/src/interfaces/admin.d.ts
+++ b/src/interfaces/admin.d.ts
@@ -6,7 +6,7 @@ import {
   BurnConfig,
   MintParams,
   BurnParams,
-} from '../configs.js';
+} from '../lib/configs.js';
 
 /**
  * Administrative operations interface for token management.

--- a/src/interfaces/core.d.ts
+++ b/src/interfaces/core.d.ts
@@ -17,7 +17,7 @@ import {
   BurnDynamicProofConfig,
   TransferDynamicProofConfig,
   UpdatesDynamicProofConfig,
-} from '../configs.js';
+} from '../lib/configs.js';
 
 /**
  * Deployment properties for the fungible token contract.

--- a/src/interfaces/sideloaded.d.ts
+++ b/src/interfaces/sideloaded.d.ts
@@ -6,7 +6,7 @@ import {
   AccountUpdateForest,
   VerificationKey,
 } from 'o1js';
-import { SideloadedProof } from '../side-loaded/program.eg.js';
+import { SideloadedProof } from '../lib/sideloaded.js';
 import { VKeyMerkleMap } from '../FungibleTokenContract.js';
 
 /**


### PR DESCRIPTION
## Description
This PR fixes the TypeScript compilation issue that happened after the recent file reorganization in #40 since I realized it still contained outdated import paths that was causing broken type definitions

## Changes
- Updated import paths in `admin.d.ts`, `core.d.ts` from `../configs.js` to `../lib/configs.js`
- Updated import path in `sideloaded.d.ts` from `../side-loaded/program.eg.js` to `../lib/sideloaded.js`

Tests pass with `proofsEnabled=true`
TypeScript compilation passes (`npx tsc --noEmit`)