### PR TITLE
Improve `proofsEnabled` DX with an env variable

### DIFF
--- a/src/test/approve.test.ts
+++ b/src/test/approve.test.ts
@@ -37,7 +37,10 @@ import {
 } from '../examples/side-loaded/program.eg.js';
 import { TEST_ERROR_MESSAGES } from './constants.js';
 
-const proofsEnabled = false;
+const proofsEnabled = process.env.PROOFS_ENABLED === 'true';
+if (!proofsEnabled) {
+  console.log('Skipping proof generation in approve tests.');
+}
 
 describe('Fungible Token - ApproveBase Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;

--- a/src/test/burn.test.ts
+++ b/src/test/burn.test.ts
@@ -32,7 +32,10 @@ import {
 } from '../examples/side-loaded/program.eg.js';
 import { TEST_ERROR_MESSAGES } from './constants.js';
 
-const proofsEnabled = false;
+const proofsEnabled = process.env.PROOFS_ENABLED === 'true';
+if (!proofsEnabled) {
+  console.log('Skipping proof generation in burn tests.');
+}
 
 describe('Fungible Token - Burn Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;

--- a/src/test/mint.test.ts
+++ b/src/test/mint.test.ts
@@ -31,7 +31,10 @@ import {
 } from '../examples/side-loaded/program.eg.js';
 import { TEST_ERROR_MESSAGES } from './constants.js';
 
-const proofsEnabled = false;
+const proofsEnabled = process.env.PROOFS_ENABLED === 'true';
+if (!proofsEnabled) {
+  console.log('Skipping proof generation in mint tests.');
+}
 
 describe('Fungible Token - Mint Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;

--- a/src/test/transfer.test.ts
+++ b/src/test/transfer.test.ts
@@ -31,7 +31,10 @@ import {
 } from '../examples/side-loaded/program.eg.js';
 import { TEST_ERROR_MESSAGES } from './constants.js';
 
-const proofsEnabled = false;
+const proofsEnabled = process.env.PROOFS_ENABLED === 'true';
+if (!proofsEnabled) {
+  console.log('Skipping proof generation in transfer tests.');
+}
 
 describe('Fungible Token - Transfer Tests', () => {
   let tokenAdmin: Mina.TestPublicKey, tokenA: Mina.TestPublicKey;


### PR DESCRIPTION
## Description
This PR improves the developer experience for managing proof generation in tests by replacing hardcoded values with environment variable control.

## Changes
- Replaced hardcoded `proofsEnabled = false` with `process.env.PROOFS_ENABLED === "true"`
- Added specific console messages for each test file when proofs are skipped
- Proofs disabled by default for faster test execution
- It's possible to enable proofs by setting `PROOFS_ENABLED=true` environment variable

## Examples
```bash
# Run tests with proofs disabled
npm test

# Run tests with proofs enabled
PROOFS_ENABLED=true npm test

# Run specific test file with proofs enabled
PROOFS_ENABLED=true npm test -- src/test/mint.test.ts
```

Tests pass with `proofsEnabled=true`